### PR TITLE
[FEAT][UHYU-74] 지도 카테고리 필터링

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/map/controller/MapController.java
+++ b/src/main/java/com/ureca/uhyu/domain/map/controller/MapController.java
@@ -39,7 +39,7 @@ public class MapController {
         return CommonResponse.success(ResultCode.SUCCESS, mapService.getStoreDetail(storeId,user));
     }
 
-    @Operation(summary = "브랜드 검색", description = "브랜드 이름으로 검색 시 반경 내 해당 브랜드 목록 반환")
+    @Operation(summary = "브랜드 검색", description = "브랜드 이름으로 검색 시 반경 내 해당 브랜드 매장 목록 반환")
     @GetMapping("/brand")
     public CommonResponse<List<MapRes>> getSearchedStoresInRange(
             @RequestParam Double lat,
@@ -47,7 +47,17 @@ public class MapController {
             @RequestParam Double radius,
             @RequestParam String brandName
     ) {
-        System.out.println("브랜드명 검색 파라미터: " + brandName);
         return CommonResponse.success(ResultCode.SUCCESS, mapService.getSearchedStoresInRange(lat, lon, radius, brandName));
+    }
+
+    @Operation(summary = "카테고리 검색", description = "카테고리 검색을 시 반경 내 해당 카테고리 매장 목록 반환")
+    @GetMapping("/category")
+    public CommonResponse<List<MapRes>> getCategoryStoreInRange(
+            @RequestParam Double lat,
+            @RequestParam Double lon,
+            @RequestParam Double radius,
+            @RequestParam String categoryName
+    ){
+        return CommonResponse.success(ResultCode.SUCCESS, mapService.getCategoryStoreInRange(lat, lon, radius, categoryName));
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/map/service/MapService.java
+++ b/src/main/java/com/ureca/uhyu/domain/map/service/MapService.java
@@ -11,4 +11,5 @@ public interface MapService {
     List<MapRes> getStoresInRange(Double lat, Double lon, Double radius);
     StoreDetailRes getStoreDetail(Long storeId, User user);
     List<com.ureca.uhyu.domain.map.dto.response.MapRes> getSearchedStoresInRange(Double lat, Double lon, Double radius, String brandName);
+    List<MapRes> getCategoryStoreInRange(Double lat, Double lon, Double radius, String categoryName);
 }

--- a/src/main/java/com/ureca/uhyu/domain/map/service/MapServiceImpl.java
+++ b/src/main/java/com/ureca/uhyu/domain/map/service/MapServiceImpl.java
@@ -26,7 +26,6 @@ public class MapServiceImpl implements MapService {
 
     @Override
     public List<MapRes> getStoresInRange(Double lat, Double lon, Double radius) {
-
         List<Store> stores = storeRepositoryCustom.findStoresInRadius(lat, lon, radius);
 
         return stores.stream()
@@ -77,6 +76,15 @@ public class MapServiceImpl implements MapService {
     @Override
     public List<MapRes> getSearchedStoresInRange(Double lat, Double lon, Double radius, String brandName) {
         List<Store> stores = storeRepositoryCustom.findSearchedStoresInRadius(lat, lon, radius,brandName);
+
+        return stores.stream()
+                .map(MapRes::from)
+                .toList();
+    }
+
+    @Override
+    public List<MapRes> getCategoryStoreInRange(Double lat, Double lon, Double radius, String categoryName) {
+        List<Store> stores = storeRepositoryCustom.findCategoryStoresInRadius(lat, lon, radius,categoryName);
 
         return stores.stream()
                 .map(MapRes::from)

--- a/src/main/java/com/ureca/uhyu/domain/store/repository/StoreRepositoryCustom.java
+++ b/src/main/java/com/ureca/uhyu/domain/store/repository/StoreRepositoryCustom.java
@@ -6,4 +6,5 @@ import java.util.List;
 public interface StoreRepositoryCustom {
     List<Store> findStoresInRadius(double lat, double lon, double radiusInKm);
     List<Store> findSearchedStoresInRadius(double lat, double lon, double radiusInKm, String brandName);
+    List<Store> findCategoryStoresInRadius(Double lat, Double lon, Double radius, String categoryName);
 }

--- a/src/main/java/com/ureca/uhyu/domain/store/repository/StoreRepositoryCustomImpl.java
+++ b/src/main/java/com/ureca/uhyu/domain/store/repository/StoreRepositoryCustomImpl.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
-public class StoreRepositoryImpl implements StoreRepositoryCustom{
+public class StoreRepositoryCustomImpl implements StoreRepositoryCustom{
     private final JPAQueryFactory queryFactory;
 
     private final QStore store = QStore.store;

--- a/src/main/java/com/ureca/uhyu/domain/store/repository/StoreRepositoryImpl.java
+++ b/src/main/java/com/ureca/uhyu/domain/store/repository/StoreRepositoryImpl.java
@@ -67,4 +67,30 @@ public class StoreRepositoryImpl implements StoreRepositoryCustom{
                 .distinct()
                 .fetch();
     }
+
+    @Override
+    public List<Store> findCategoryStoresInRadius(Double lat, Double lon, Double radius, String categoryName) {
+        QStore store = QStore.store;
+        QBrand brand = QBrand.brand;
+        QCategory category = QCategory.category;
+        QBenefit benefit = QBenefit.benefit;
+
+        return queryFactory
+                .selectFrom(store)
+                .leftJoin(store.brand, brand).fetchJoin()
+                .leftJoin(brand.category, category).fetchJoin()
+                .leftJoin(brand.benefits, benefit).fetchJoin()
+                .where(
+                        Expressions.booleanTemplate(
+                                "cast(ST_DWithin(" +
+                                        "ST_Transform({0}, 3857), " +
+                                        "ST_Transform(ST_SetSRID(ST_MakePoint({1}, {2}), 4326), 3857), " +
+                                        "{3}) as boolean)",
+                                store.geom, lon, lat, radius
+                        ),
+                        category.categoryName.containsIgnoreCase(categoryName)
+                )
+                .distinct()
+                .fetch();
+    }
 }

--- a/src/main/java/com/ureca/uhyu/domain/store/repository/StoreRepositoryImpl.java
+++ b/src/main/java/com/ureca/uhyu/domain/store/repository/StoreRepositoryImpl.java
@@ -17,80 +17,58 @@ import java.util.List;
 public class StoreRepositoryImpl implements StoreRepositoryCustom{
     private final JPAQueryFactory queryFactory;
 
-    @Override
-    public List<Store> findStoresInRadius(double lat, double lon, double radius) {
-        QStore store = QStore.store;
-        QBrand brand = QBrand.brand;
-        QCategory category = QCategory.category;
-        QBenefit benefit = QBenefit.benefit;
+    private final QStore store = QStore.store;
+    private final QBrand brand = QBrand.brand;
+    private final QCategory category = QCategory.category;
+    private final QBenefit benefit = QBenefit.benefit;
 
+    private com.querydsl.core.types.Predicate withinRadius(double lat, double lon, double radius) {
+        return Expressions.booleanTemplate(
+                "cast(ST_DWithin(" +
+                        "ST_Transform({0}, 3857), " +
+                        "ST_Transform(ST_SetSRID(ST_MakePoint({1}, {2}), 4326), 3857), " +
+                        "{3}) as boolean)",
+                store.geom, lon, lat, radius
+        );
+    }
+
+    private JPAQueryFactory baseQuery() {
+        return queryFactory;
+    }
+
+    private com.querydsl.jpa.impl.JPAQuery<Store> baseStoreQuery() {
         return queryFactory
                 .selectFrom(store)
                 .leftJoin(store.brand, brand).fetchJoin()
                 .leftJoin(brand.category, category).fetchJoin()
                 .leftJoin(brand.benefits, benefit).fetchJoin()
-                .where(
-                        Expressions.booleanTemplate(
-                                "cast(ST_DWithin(" +
-                                        "ST_Transform({0}, 3857), " +
-                                        "ST_Transform(ST_SetSRID(ST_MakePoint({1}, {2}), 4326), 3857), " +
-                                        "{3}) as boolean)",
-                                store.geom, lon, lat, radius
-                        )
-                )
-                .distinct()
+                .distinct();
+    }
+
+    @Override
+    public List<Store> findStoresInRadius(double lat, double lon, double radius) {
+        return baseStoreQuery()
+                .where(withinRadius(lat, lon, radius))
                 .fetch();
     }
 
     @Override
     public List<Store> findSearchedStoresInRadius(double lat, double lon, double radius, String brandName) {
-        QStore store = QStore.store;
-        QBrand brand = QBrand.brand;
-        QCategory category = QCategory.category;
-        QBenefit benefit = QBenefit.benefit;
-
-        return queryFactory
-                .selectFrom(store)
-                .leftJoin(store.brand, brand).fetchJoin()
-                .leftJoin(brand.category, category).fetchJoin()
-                .leftJoin(brand.benefits, benefit).fetchJoin()
+        return baseStoreQuery()
                 .where(
-                        Expressions.booleanTemplate(
-                                "cast(ST_DWithin(" +
-                                        "ST_Transform({0}, 3857), " +
-                                        "ST_Transform(ST_SetSRID(ST_MakePoint({1}, {2}), 4326), 3857), " +
-                                        "{3}) as boolean)",
-                                store.geom, lon, lat, radius
-                        ),
+                        withinRadius(lat, lon, radius),
                         brand.brandName.containsIgnoreCase(brandName)
                 )
-                .distinct()
                 .fetch();
     }
 
     @Override
     public List<Store> findCategoryStoresInRadius(Double lat, Double lon, Double radius, String categoryName) {
-        QStore store = QStore.store;
-        QBrand brand = QBrand.brand;
-        QCategory category = QCategory.category;
-        QBenefit benefit = QBenefit.benefit;
-
-        return queryFactory
-                .selectFrom(store)
-                .leftJoin(store.brand, brand).fetchJoin()
-                .leftJoin(brand.category, category).fetchJoin()
-                .leftJoin(brand.benefits, benefit).fetchJoin()
+        return baseStoreQuery()
                 .where(
-                        Expressions.booleanTemplate(
-                                "cast(ST_DWithin(" +
-                                        "ST_Transform({0}, 3857), " +
-                                        "ST_Transform(ST_SetSRID(ST_MakePoint({1}, {2}), 4326), 3857), " +
-                                        "{3}) as boolean)",
-                                store.geom, lon, lat, radius
-                        ),
+                        withinRadius(lat, lon, radius),
                         category.categoryName.containsIgnoreCase(categoryName)
                 )
-                .distinct()
                 .fetch();
     }
 }

--- a/src/test/java/com/ureca/uhyu/domain/map/service/MapServiceImplTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/map/service/MapServiceImplTest.java
@@ -85,6 +85,52 @@ class MapServiceImplTest {
     }
 
     @Nested
+    class GetCategoryStoreInRangeTest {
+
+        @Test
+        void shouldReturnStoresMatchingCategoryInRange() {
+            // given
+            double lat = 37.5;
+            double lon = 127.0;
+            double radius = 1000.0;
+            String categoryName = "커피";
+
+            when(storeRepositoryCustom.findCategoryStoresInRadius(lat, lon, radius, categoryName))
+                    .thenReturn(List.of(store));
+
+            // when
+            List<MapRes> result = mapService.getCategoryStoreInRange(lat, lon, radius, categoryName);
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).storeName()).isEqualTo("이디야 판교점");
+        }
+    }
+
+    @Nested
+    class GetBrandStoreInRangeTest {
+
+        @Test
+        void shouldReturnStoresMatchingBrandInRange() {
+            // given
+            double lat = 37.5;
+            double lon = 127.0;
+            double radius = 1000.0;
+            String brandName = "이디야.";
+
+            when(storeRepositoryCustom.findSearchedStoresInRadius(lat, lon, radius, brandName))
+                    .thenReturn(List.of(store));
+
+            // when
+            List<MapRes> result = mapService.getSearchedStoresInRange(lat, lon, radius, brandName);
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).storeName()).isEqualTo("이디야 판교점");
+        }
+    }
+
+    @Nested
     class GetStoreDetailTest {
 
         @Test


### PR DESCRIPTION
## 📌 작업 개요

- 지도에서 카테고리 필터링 기능을 구현합니다.
- StoreRepositoryCustomImpl에서 중복코드를 최소화 하기 위해서 리팩토링

## ✨ 기타 참고 사항

- 특이사항은 없습니다. 

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.
