### PR TITLE
[FEAT][UHYU-73] 이중 필터링 구현 및 구현을 위한 코드 리팩토링

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/map/controller/MapController.java
+++ b/src/main/java/com/ureca/uhyu/domain/map/controller/MapController.java
@@ -20,14 +20,15 @@ public class MapController {
 
     private final MapService mapService;
 
-    @Operation(summary = "범위 내 제휴 매장 조회", description = "중심 좌표와 반경을 기준으로 제휴 매장 조회")
-    @GetMapping
-    public CommonResponse<List<MapRes>> getStoresInRange(
+    @GetMapping("/stores")
+    public CommonResponse<List<MapRes>> getFilteredStores(
             @RequestParam Double lat,
             @RequestParam Double lon,
-            @RequestParam Double radius
+            @RequestParam Double radius,
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) String brand
     ) {
-        return CommonResponse.success(ResultCode.SUCCESS, mapService.getStoresInRange(lat, lon, radius));
+        return CommonResponse.success(ResultCode.SUCCESS, mapService.getFilteredStores(lat, lon, radius, category, brand));
     }
 
     @Operation(summary = "매장 상세정보 조회", description = "지도 마커를 클릭하면 등급별 혜택/제공 횟수/이용방법을 반환")
@@ -37,27 +38,5 @@ public class MapController {
             @CurrentUser User user
     ){
         return CommonResponse.success(ResultCode.SUCCESS, mapService.getStoreDetail(storeId,user));
-    }
-
-    @Operation(summary = "브랜드 검색", description = "브랜드 이름으로 검색 시 반경 내 해당 브랜드 매장 목록 반환")
-    @GetMapping("/brand")
-    public CommonResponse<List<MapRes>> getSearchedStoresInRange(
-            @RequestParam Double lat,
-            @RequestParam Double lon,
-            @RequestParam Double radius,
-            @RequestParam String brandName
-    ) {
-        return CommonResponse.success(ResultCode.SUCCESS, mapService.getSearchedStoresInRange(lat, lon, radius, brandName));
-    }
-
-    @Operation(summary = "카테고리 검색", description = "카테고리 검색을 시 반경 내 해당 카테고리 매장 목록 반환")
-    @GetMapping("/category")
-    public CommonResponse<List<MapRes>> getCategoryStoreInRange(
-            @RequestParam Double lat,
-            @RequestParam Double lon,
-            @RequestParam Double radius,
-            @RequestParam String categoryName
-    ){
-        return CommonResponse.success(ResultCode.SUCCESS, mapService.getCategoryStoreInRange(lat, lon, radius, categoryName));
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/map/service/MapService.java
+++ b/src/main/java/com/ureca/uhyu/domain/map/service/MapService.java
@@ -8,8 +8,6 @@ import com.ureca.uhyu.domain.user.entity.User;
 import java.util.List;
 
 public interface MapService {
-    List<MapRes> getStoresInRange(Double lat, Double lon, Double radius);
+    List<MapRes> getFilteredStores(Double lat, Double lon, Double radius, String category, String brand);
     StoreDetailRes getStoreDetail(Long storeId, User user);
-    List<com.ureca.uhyu.domain.map.dto.response.MapRes> getSearchedStoresInRange(Double lat, Double lon, Double radius, String brandName);
-    List<MapRes> getCategoryStoreInRange(Double lat, Double lon, Double radius, String categoryName);
 }

--- a/src/main/java/com/ureca/uhyu/domain/map/service/MapServiceImpl.java
+++ b/src/main/java/com/ureca/uhyu/domain/map/service/MapServiceImpl.java
@@ -25,14 +25,12 @@ public class MapServiceImpl implements MapService {
     private final StoreRepository storeRepository;
 
     @Override
-    public List<MapRes> getStoresInRange(Double lat, Double lon, Double radius) {
-        List<Store> stores = storeRepositoryCustom.findStoresInRadius(lat, lon, radius);
-
+    public List<MapRes> getFilteredStores(Double lat, Double lon, Double radius, String categoryName, String brandName) {
+        List<Store> stores = storeRepositoryCustom.findStoresByFilters(lat, lon, radius, categoryName, brandName);
         return stores.stream()
                 .map(MapRes::from)
                 .toList();
     }
-
 
     @Override
     public StoreDetailRes getStoreDetail(Long storeId, User user) {
@@ -71,23 +69,5 @@ public class MapServiceImpl implements MapService {
                 brand.getUsageLimit(),
                 brand.getUsageMethod()
         );
-    }
-
-    @Override
-    public List<MapRes> getSearchedStoresInRange(Double lat, Double lon, Double radius, String brandName) {
-        List<Store> stores = storeRepositoryCustom.findSearchedStoresInRadius(lat, lon, radius,brandName);
-
-        return stores.stream()
-                .map(MapRes::from)
-                .toList();
-    }
-
-    @Override
-    public List<MapRes> getCategoryStoreInRange(Double lat, Double lon, Double radius, String categoryName) {
-        List<Store> stores = storeRepositoryCustom.findCategoryStoresInRadius(lat, lon, radius,categoryName);
-
-        return stores.stream()
-                .map(MapRes::from)
-                .toList();
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/store/repository/StoreRepositoryCustom.java
+++ b/src/main/java/com/ureca/uhyu/domain/store/repository/StoreRepositoryCustom.java
@@ -4,7 +4,5 @@ import com.ureca.uhyu.domain.store.entity.Store;
 import java.util.List;
 
 public interface StoreRepositoryCustom {
-    List<Store> findStoresInRadius(double lat, double lon, double radiusInKm);
-    List<Store> findSearchedStoresInRadius(double lat, double lon, double radiusInKm, String brandName);
-    List<Store> findCategoryStoresInRadius(Double lat, Double lon, Double radius, String categoryName);
+    List<Store> findStoresByFilters(Double lat, Double lon, Double radius, String categoryName, String brandName);
 }

--- a/src/test/java/com/ureca/uhyu/domain/map/service/MapServiceImplTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/map/service/MapServiceImplTest.java
@@ -63,68 +63,68 @@ class MapServiceImplTest {
             .build();
 
     @Nested
-    class GetStoresInRangeTest {
+    class GetFilteredStoresTest {
 
         @Test
-        void shouldReturnMappedStoreList() {
-            // given
+        void shouldReturnStoresWithCategoryAndBrandFilters() {
             double lat = 37.5;
             double lon = 127.0;
             double radius = 1000.0;
+            String categoryName = "카페";
+            String brandName = "이디야";
 
-            when(storeRepositoryCustom.findStoresInRadius(lat, lon, radius))
+            when(storeRepositoryCustom.findStoresByFilters(lat, lon, radius, categoryName, brandName))
                     .thenReturn(List.of(store));
 
-            // when
-            List<MapRes> result = mapService.getStoresInRange(lat, lon, radius);
+            List<MapRes> result = mapService.getFilteredStores(lat, lon, radius, categoryName, brandName);
 
-            // then
             assertThat(result).hasSize(1);
             assertThat(result.get(0).storeName()).isEqualTo("이디야 판교점");
         }
-    }
-
-    @Nested
-    class GetCategoryStoreInRangeTest {
 
         @Test
-        void shouldReturnStoresMatchingCategoryInRange() {
-            // given
+        void shouldReturnStoresWithOnlyCategoryFilter() {
             double lat = 37.5;
             double lon = 127.0;
             double radius = 1000.0;
-            String categoryName = "커피";
+            String categoryName = "카페";
 
-            when(storeRepositoryCustom.findCategoryStoresInRadius(lat, lon, radius, categoryName))
+            when(storeRepositoryCustom.findStoresByFilters(lat, lon, radius, categoryName, null))
                     .thenReturn(List.of(store));
 
-            // when
-            List<MapRes> result = mapService.getCategoryStoreInRange(lat, lon, radius, categoryName);
+            List<MapRes> result = mapService.getFilteredStores(lat, lon, radius, categoryName, null);
 
-            // then
             assertThat(result).hasSize(1);
             assertThat(result.get(0).storeName()).isEqualTo("이디야 판교점");
         }
-    }
-
-    @Nested
-    class GetBrandStoreInRangeTest {
 
         @Test
-        void shouldReturnStoresMatchingBrandInRange() {
-            // given
+        void shouldReturnStoresWithOnlyBrandFilter() {
             double lat = 37.5;
             double lon = 127.0;
             double radius = 1000.0;
-            String brandName = "이디야.";
+            String brandName = "이디야";
 
-            when(storeRepositoryCustom.findSearchedStoresInRadius(lat, lon, radius, brandName))
+            when(storeRepositoryCustom.findStoresByFilters(lat, lon, radius, null, brandName))
                     .thenReturn(List.of(store));
 
-            // when
-            List<MapRes> result = mapService.getSearchedStoresInRange(lat, lon, radius, brandName);
+            List<MapRes> result = mapService.getFilteredStores(lat, lon, radius, null, brandName);
 
-            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).storeName()).isEqualTo("이디야 판교점");
+        }
+
+        @Test
+        void shouldReturnStoresWithoutAnyFilter() {
+            double lat = 37.5;
+            double lon = 127.0;
+            double radius = 1000.0;
+
+            when(storeRepositoryCustom.findStoresByFilters(lat, lon, radius, null, null))
+                    .thenReturn(List.of(store));
+
+            List<MapRes> result = mapService.getFilteredStores(lat, lon, radius, null, null);
+
             assertThat(result).hasSize(1);
             assertThat(result.get(0).storeName()).isEqualTo("이디야 판교점");
         }
@@ -135,7 +135,6 @@ class MapServiceImplTest {
 
         @Test
         void shouldReturnBenefitMatchingUserGrade() {
-            // given
             User user = mock(User.class);
             when(user.getGrade()).thenReturn(Grade.VIP);
 
@@ -146,22 +145,18 @@ class MapServiceImplTest {
                     .build();
 
             brand.setBenefits(List.of(vipBenefit));
-
             when(storeRepository.findById(1L)).thenReturn(Optional.of(store));
 
-            // when
             StoreDetailRes res = mapService.getStoreDetail(1L, user);
 
-            // then
             assertThat(res.benefits().benefitText()).isEqualTo("음료 2잔 무료");
             assertThat(res.usageLimit()).isEqualTo("1일 1회");
         }
 
         @Test
         void shouldReturnGoodBenefitIfNoExactMatch() {
-            // given
             User user = mock(User.class);
-            when(user.getGrade()).thenReturn(Grade.VIP); // fallback 케이스
+            when(user.getGrade()).thenReturn(Grade.VIP);
 
             Benefit goodBenefit = Benefit.builder()
                     .grade(Grade.GOOD)
@@ -170,31 +165,24 @@ class MapServiceImplTest {
                     .build();
 
             brand.setBenefits(List.of(goodBenefit));
-
             when(storeRepository.findById(1L)).thenReturn(Optional.of(store));
 
-            // when
             StoreDetailRes res = mapService.getStoreDetail(1L, user);
 
-            // then
             assertThat(res.benefits().grade()).isEqualTo("GOOD");
             assertThat(res.benefits().benefitText()).isEqualTo("1+1 혜택");
         }
 
         @Test
         void shouldReturnNullIfNoBenefitExists() {
-            // given
             User user = mock(User.class);
             when(user.getGrade()).thenReturn(Grade.VIP);
 
-            brand.setBenefits(List.of()); // 혜택 없음
-
+            brand.setBenefits(List.of());
             when(storeRepository.findById(1L)).thenReturn(Optional.of(store));
 
-            // when
             StoreDetailRes res = mapService.getStoreDetail(1L, user);
 
-            // then
             assertThat(res.benefits()).isNull();
         }
     }


### PR DESCRIPTION
## 📌 작업 개요

- 브랜드 + 카테고리 필터링 구현
- 구현에 따른 API 통합 -> null 여부로 Service 단에서 분기처리
- StoreRepositoryImpl 코드 수정 

## ✨ 기타 참고 사항

- 결국 쿼리 파라미터로 brandName이랑 categoryName이 들어오는지 안들어오는지 여부를 확인해서 분기처리를 합니다. 

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.
