### PR TITLE
[FEAT][UHYU-97] 즐겨찾기 추가/삭제 및 매장상세보기 즐겨찾기 정보 추가

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/map/controller/MapController.java
+++ b/src/main/java/com/ureca/uhyu/domain/map/controller/MapController.java
@@ -21,6 +21,7 @@ public class MapController {
 
     private final MapService mapService;
 
+    @Operation(summary = "지도 매장 겁색", description = "브랜드명 검색, 필터링, 기본 조회 API")
     @GetMapping("/stores")
     public CommonResponse<List<MapRes>> getFilteredStores(
             @RequestParam Double lat,

--- a/src/main/java/com/ureca/uhyu/domain/map/controller/MapController.java
+++ b/src/main/java/com/ureca/uhyu/domain/map/controller/MapController.java
@@ -1,5 +1,6 @@
 package com.ureca.uhyu.domain.map.controller;
 
+import com.ureca.uhyu.domain.map.dto.response.MapBookmarkRes;
 import com.ureca.uhyu.domain.map.dto.response.MapRes;
 import com.ureca.uhyu.domain.map.service.MapService;
 import com.ureca.uhyu.domain.store.dto.response.StoreDetailRes;
@@ -38,5 +39,14 @@ public class MapController {
             @CurrentUser User user
     ){
         return CommonResponse.success(ResultCode.SUCCESS, mapService.getStoreDetail(storeId,user));
+    }
+
+    @Operation(summary = "매장 즐겨찾기 토글", description = "매장 상세정보에서 즐겨찾기 토글 버튼 API")
+    @PostMapping("/{storeId}")
+    public CommonResponse<MapBookmarkRes> toggleBookmark(
+            @PathVariable Long storeId,
+            @CurrentUser User user
+    ) {
+        return CommonResponse.success(ResultCode.SUCCESS, mapService.toggleBookmark(user, storeId));
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/map/dto/response/MapBookmarkRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/map/dto/response/MapBookmarkRes.java
@@ -1,0 +1,12 @@
+package com.ureca.uhyu.domain.map.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "즐겨찾기 추가/해제 응답 DTO")
+public record MapBookmarkRes(
+        @Schema(description = "매장 ID")
+        Long storeId,
+
+        @Schema(description = "즐겨찾기 여부")
+        boolean isBookmarked
+) {}

--- a/src/main/java/com/ureca/uhyu/domain/map/service/MapService.java
+++ b/src/main/java/com/ureca/uhyu/domain/map/service/MapService.java
@@ -1,6 +1,7 @@
 package com.ureca.uhyu.domain.map.service;
 
 
+import com.ureca.uhyu.domain.map.dto.response.MapBookmarkRes;
 import com.ureca.uhyu.domain.map.dto.response.MapRes;
 import com.ureca.uhyu.domain.store.dto.response.StoreDetailRes;
 import com.ureca.uhyu.domain.user.entity.User;
@@ -10,4 +11,5 @@ import java.util.List;
 public interface MapService {
     List<MapRes> getFilteredStores(Double lat, Double lon, Double radius, String category, String brand);
     StoreDetailRes getStoreDetail(Long storeId, User user);
+    MapBookmarkRes toggleBookmark(User user, Long storeId);
 }

--- a/src/main/java/com/ureca/uhyu/domain/map/service/MapServiceImpl.java
+++ b/src/main/java/com/ureca/uhyu/domain/map/service/MapServiceImpl.java
@@ -48,14 +48,11 @@ public class MapServiceImpl implements MapService {
         Brand brand = store.getBrand();
         Grade userGrade = user.getGrade();
 
-        List<Benefit> benefits = brand.getBenefits();
-
-        // 1. 유저 등급과 일치하는 혜택 먼저 찾기
+        // 등급별 혜택 조회
         Optional<Benefit> matchingBenefit = brand.getBenefits().stream()
                 .filter(b -> b.getGrade() == userGrade)
                 .findFirst();
 
-        // 2. 없으면 GOOD 혜택 fallback
         Benefit selected = matchingBenefit.orElseGet(() ->
                 brand.getBenefits().stream()
                         .filter(b -> b.getGrade() == Grade.GOOD)
@@ -71,8 +68,14 @@ public class MapServiceImpl implements MapService {
             );
         }
 
+        // 🔽 즐겨찾기 관련 정보 조회
+        boolean isFavorite = bookmarkRepository.existsByBookmarkListUserAndStore(user, store);
+        int favoriteCount = bookmarkRepository.countByStore(store);
+
         return new StoreDetailRes(
                 store.getName(),
+                isFavorite,
+                favoriteCount,
                 benefitDetail,
                 brand.getUsageLimit(),
                 brand.getUsageMethod()

--- a/src/main/java/com/ureca/uhyu/domain/store/dto/response/StoreDetailRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/store/dto/response/StoreDetailRes.java
@@ -8,13 +8,11 @@ public record StoreDetailRes(
         @Schema(description = "매장명")
         String storeName,
 
-        /** TODO 추후 즐겨찾기 관련 로직 구현 이후 추가
-         * @Schema(description = "즐겨찾기 여부")
-         * boolean isFavorite,
-         *
-         * @Schema(description = "즐겨찾기 수")
-         * int favoriteCount,
-        */
+        @Schema(description = "즐겨찾기 여부")
+        boolean isFavorite,
+
+        @Schema(description = "즐겨찾기 수")
+        int favoriteCount,
 
         @Schema(description = "선택된 혜택 (등급별 1개)")
         BenefitDetail benefits,

--- a/src/main/java/com/ureca/uhyu/domain/user/repository/BookmarkListRepository.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/repository/BookmarkListRepository.java
@@ -4,6 +4,8 @@ import com.ureca.uhyu.domain.user.entity.BookmarkList;
 import com.ureca.uhyu.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface BookmarkListRepository extends JpaRepository<BookmarkList, Long> {
-    BookmarkList findByUser(User user);
+    Optional<BookmarkList> findByUser(User user);
 }

--- a/src/main/java/com/ureca/uhyu/domain/user/repository/BookmarkRepository.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/repository/BookmarkRepository.java
@@ -1,11 +1,17 @@
 package com.ureca.uhyu.domain.user.repository;
 
+import com.ureca.uhyu.domain.store.entity.Store;
 import com.ureca.uhyu.domain.user.entity.Bookmark;
 import com.ureca.uhyu.domain.user.entity.BookmarkList;
+import com.ureca.uhyu.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     List<Bookmark> findByBookmarkList(BookmarkList bookmarkList);
+    Optional<Bookmark> findByBookmarkListAndStore(BookmarkList bookmarkList, Store store);
+    boolean existsByBookmarkListUserAndStore(User user, Store store);
+    int countByStore(Store store);
 }

--- a/src/main/java/com/ureca/uhyu/domain/user/service/UserService.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/service/UserService.java
@@ -122,7 +122,8 @@ public class UserService {
     }
 
     public List<BookmarkRes> findBookmarkList(User user) {
-        BookmarkList bookmarkList = bookmarkListRepository.findByUser(user);
+        BookmarkList bookmarkList = bookmarkListRepository.findByUser(user)
+                .orElseThrow(() -> new GlobalException(ResultCode.BOOKMARK_LIST_NOT_FOUND));
         List<Bookmark> bookmarks = bookmarkRepository.findByBookmarkList(bookmarkList);
 
         return bookmarks.stream()

--- a/src/main/java/com/ureca/uhyu/global/response/ResultCode.java
+++ b/src/main/java/com/ureca/uhyu/global/response/ResultCode.java
@@ -40,7 +40,8 @@ public enum ResultCode {
     EMAIL_CHECK_SUCCESS(HttpStatus.OK, 4002, "사용 가능한 이메일 입니다."),
     EMAIL_DUPLICATED(HttpStatus.BAD_REQUEST, 4003, "이미 사용중인 이메일입니다."),
     BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, 4004, "즐겨찾기 정보를 찾을 수 없습니다."),
-    BOOKMARK_DELETE_SUCCESS(HttpStatus.OK, 4005, "즐겨찾기 삭제가 완료되었습니다.");
+    BOOKMARK_DELETE_SUCCESS(HttpStatus.OK, 4005, "즐겨찾기 삭제가 완료되었습니다."),
+    BOOKMARK_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, 4006, "즐겨찾기 리스트가 없습니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/test/java/com/ureca/uhyu/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/user/service/UserServiceTest.java
@@ -209,7 +209,7 @@ class UserServiceTest {
         List<Bookmark> bookmarks = List.of(bookmark);
 
         // mock
-        when(bookmarkListRepository.findByUser(user)).thenReturn(bookmarkList);
+        when(bookmarkListRepository.findByUser(user)).thenReturn(Optional.of(bookmarkList));
         when(bookmarkRepository.findByBookmarkList(bookmarkList)).thenReturn(bookmarks);
 
         // when


### PR DESCRIPTION
## 📌 작업 개요

- 매장 상세보기 페이지에서 해당 매장을 즐겨찾기에 추가/삭제하는 토글 버튼 API 구현
- 매장 상세보기 dto "즐겨찾기 여부"와 "해당 매장을 즐겨찾기한 사람 수"를 추가

## ✨ 기타 참고 사항

- 즐겨찾기 관련 로직이 완료되어서 매장 상세보기에 추가했습니다.
- 즐겨찾기 버튼 누르면서 상세보기에서 반환값에 반영되는지도 확인했습니다!

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.
