### PR TITLE
[FIX][UHYU-86] jwt 관련 로그인 에러 수정 및 이메일 중복확인 관련 Post 요청으로 수정

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/auth/dto/UserEmailCheckRequest.java
+++ b/src/main/java/com/ureca/uhyu/domain/auth/dto/UserEmailCheckRequest.java
@@ -1,0 +1,5 @@
+package com.ureca.uhyu.domain.auth.dto;
+
+public record UserEmailCheckRequest (
+    String email
+) {}

--- a/src/main/java/com/ureca/uhyu/domain/auth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/ureca/uhyu/domain/auth/handler/OAuth2SuccessHandler.java
@@ -47,7 +47,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         UserRole userRole = customOAuth2User.getUserRole();
         Boolean isNewUser = customOAuth2User.isNewUser();
 
-        log.info("토큰 발급");
+        log.info("~~ 토큰 발급 ~~");
 
         Cookie accessCookie = tokenService.createAccessTokenCookie(String.valueOf(userId), userRole);
 
@@ -56,17 +56,29 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         response.addCookie(accessCookie);
 
         // ~~신규/기존 유저에 따라 redirect~~ -> 유저 role에 따라 Redirect
-        String redirectUrl = resolveRedirectUrl(userRole);
+        String redirectUrl = resolveRedirectUrl(request, userRole);
 
         response.setStatus(HttpServletResponse.SC_FOUND);
         response.setHeader("Location", redirectUrl);
     }
 
-    private String resolveRedirectUrl(UserRole userRole) {
+    private String resolveRedirectUrl(HttpServletRequest request, UserRole userRole) {
+
         if (userRole == UserRole.TMP_USER) {
             return "http://localhost:5173/user/extra-info";
         } else {
             return "http://localhost:5173";
         }
+
+//        String host = request.getHeader("host");
+//        String frontBaseUrl = (host != null && host.contains("localhost"))
+//                ? "http://localhost:3000"
+//                : "http://localhost:5173";
+//
+//        if (userRole == UserRole.TMP_USER) {
+//            return frontBaseUrl + "/user/extra-info";
+//        } else {
+//            return frontBaseUrl;
+//        }
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ureca/uhyu/domain/auth/jwt/JwtAuthenticationFilter.java
@@ -46,15 +46,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     FilterChain filterChain) throws ServletException, IOException {
         try {
             String accessToken = extractAccessTokenFromCookie(request);
-            if (accessToken == null) {
-                log.warn("🚫 access_token 쿠키가 요청에 포함되어 있지 않습니다.");
-            } else {
-                log.info("📦 들어온 access_token: {}", accessToken);
-            }
 
             if (accessToken != null && jwtTokenProvider.validateToken(accessToken)) {
-
-                log.info("✅ access_token 유효함");
 
                 String userId = jwtTokenProvider.getUserIdFromToken(accessToken);
                 String role = jwtTokenProvider.getRoleFromToken(accessToken);
@@ -69,15 +62,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
 
             String expiredAccessToken = extractAccessTokenFromCookie(request);
-            log.warn("📛 access_token이 유효하지 않거나 만료됨. expiredAccessToken 재시도: {}", expiredAccessToken);
 
             String userId = jwtTokenProvider.getUserIdFromExpiredToken(expiredAccessToken);
 
             String refreshToken = tokenRepository.findTokenByUserId(Long.parseLong(userId))
                 .map(token -> token.getRefreshToken())
                 .orElse(null);
-
-            log.info("📦 추출된 refresh 토큰: {}", refreshToken);
 
             if (refreshToken != null && jwtTokenProvider.validateToken(refreshToken)) {
                 String roleString = jwtTokenProvider.getRoleFromToken(refreshToken);
@@ -87,7 +77,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 UserRole userRole = UserRole.valueOf(roleString);
                 String newAccessToken = jwtTokenProvider.generateToken(userId, userRole);
-                log.info("🔁 새 access_token 발급 완료: {}", newAccessToken);
+
                 Cookie newAccessTokenCookie = new Cookie("access_token", newAccessToken);
                 newAccessTokenCookie.setHttpOnly(true);
                 newAccessTokenCookie.setPath("/");

--- a/src/main/java/com/ureca/uhyu/domain/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ureca/uhyu/domain/auth/jwt/JwtAuthenticationFilter.java
@@ -46,8 +46,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     FilterChain filterChain) throws ServletException, IOException {
         try {
             String accessToken = extractAccessTokenFromCookie(request);
+            if (accessToken == null) {
+                log.warn("🚫 access_token 쿠키가 요청에 포함되어 있지 않습니다.");
+            } else {
+                log.info("📦 들어온 access_token: {}", accessToken);
+            }
 
             if (accessToken != null && jwtTokenProvider.validateToken(accessToken)) {
+
+                log.info("✅ access_token 유효함");
+
                 String userId = jwtTokenProvider.getUserIdFromToken(accessToken);
                 String role = jwtTokenProvider.getRoleFromToken(accessToken);
 
@@ -61,10 +69,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
 
             String expiredAccessToken = extractAccessTokenFromCookie(request);
+            log.warn("📛 access_token이 유효하지 않거나 만료됨. expiredAccessToken 재시도: {}", expiredAccessToken);
+
             String userId = jwtTokenProvider.getUserIdFromExpiredToken(expiredAccessToken);
 
-            String refreshToken = tokenRepository.findTokenByUserId(Long.parseLong(userId)).toString();
-            //String refreshToken = tokenRepository.findRefreshTokenByUserId(userId);
+            String refreshToken = tokenRepository.findTokenByUserId(Long.parseLong(userId))
+                .map(token -> token.getRefreshToken())
+                .orElse(null);
+
+            log.info("📦 추출된 refresh 토큰: {}", refreshToken);
 
             if (refreshToken != null && jwtTokenProvider.validateToken(refreshToken)) {
                 String roleString = jwtTokenProvider.getRoleFromToken(refreshToken);
@@ -74,6 +87,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 UserRole userRole = UserRole.valueOf(roleString);
                 String newAccessToken = jwtTokenProvider.generateToken(userId, userRole);
+                log.info("🔁 새 access_token 발급 완료: {}", newAccessToken);
                 Cookie newAccessTokenCookie = new Cookie("access_token", newAccessToken);
                 newAccessTokenCookie.setHttpOnly(true);
                 newAccessTokenCookie.setPath("/");

--- a/src/main/java/com/ureca/uhyu/domain/auth/repository/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/ureca/uhyu/domain/auth/repository/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -19,8 +19,15 @@ public class HttpCookieOAuth2AuthorizationRequestRepository implements Authoriza
 
     @Override
     public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
-        return getCookie(request, OAUTH2_AUTH_REQUEST_COOKIE_NAME)
-                .map(cookie -> deserialize(cookie.getValue()))
+//        return getCookie(request, OAUTH2_AUTH_REQUEST_COOKIE_NAME)
+//                .map(cookie -> deserialize(cookie.getValue()))
+        Optional<Cookie> authRequestCookie = getCookie(request, OAUTH2_AUTH_REQUEST_COOKIE_NAME);
+        if (authRequestCookie.isEmpty()) {
+            System.out.println("⚠️ OAUTH2_AUTH_REQUEST 쿠키가 요청에 존재하지 않습니다.");
+        } else {
+            System.out.println("✅ OAUTH2_AUTH_REQUEST 쿠키가 존재하며, 값: " + authRequestCookie.get().getValue());
+        }
+        return authRequestCookie.map(cookie -> deserialize(cookie.getValue()))
                 .orElse(null);
     }
 

--- a/src/main/java/com/ureca/uhyu/domain/auth/repository/TokenRepository.java
+++ b/src/main/java/com/ureca/uhyu/domain/auth/repository/TokenRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import javax.swing.text.html.Option;
 import java.util.Optional;
 
 @Repository
@@ -22,7 +23,7 @@ public interface TokenRepository extends JpaRepository<Token, Long> {
 
     Optional<Token> findByUserId(Long id);
 
-    Long findTokenByUserId(Long userId);
+    Optional<Token> findTokenByUserId(Long userId);
 
     @Transactional
     @Modifying

--- a/src/main/java/com/ureca/uhyu/domain/auth/service/TokenService.java
+++ b/src/main/java/com/ureca/uhyu/domain/auth/service/TokenService.java
@@ -8,6 +8,7 @@ import com.ureca.uhyu.domain.user.enums.UserRole;
 import jakarta.servlet.http.Cookie;
 import lombok.RequiredArgsConstructor;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -16,6 +17,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TokenService {
@@ -48,6 +50,7 @@ public class TokenService {
 
     // Access 토큰 쿠키 생성
     public Cookie createAccessTokenCookie(String userId, UserRole role) {
+        log.info("access 토큰 쿠키 생성");
         String accessToken = jwtTokenProvider.generateToken(userId, role);
         return buildHttpOnlyCookie("access_token", accessToken, jwtTokenProvider.getAccessTokenExp());
     }
@@ -56,6 +59,7 @@ public class TokenService {
     public void createRefreshToken(User user) {
         String refreshToken = jwtTokenProvider.generateToken(
                 String.valueOf(user.getId()), user.getUserRole());
+        log.info("refresh 토큰 저장");
         saveOrUpdateRefreshToken(user, refreshToken);
     }
 

--- a/src/main/java/com/ureca/uhyu/domain/user/controller/UserController.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.ureca.uhyu.domain.user.controller;
 
+import com.ureca.uhyu.domain.auth.dto.UserEmailCheckRequest;
 import com.ureca.uhyu.domain.auth.service.TokenService;
 import com.ureca.uhyu.domain.user.dto.request.UserOnboardingRequest;
 import com.ureca.uhyu.domain.user.dto.request.UpdateUserReq;
@@ -46,7 +47,7 @@ public class UserController {
 
         response.addCookie(accessCookie);
 
-        return CommonResponse.success(ResultCode.USER_ONBOARDING_SUCCESS);
+        return CommonResponse.success(ResultCode.USER_ONBOARDING_SUCCESS, null);
     }
 
     @Operation(summary = "개인정보 조회", description = "개인정보 조회: 로그인 필요")
@@ -65,10 +66,10 @@ public class UserController {
     }
 
     @Operation(summary = "이메일 중복 확인", description = "신규 유저 이메일 입력 중복 확인")
-    @GetMapping("/check-email")
-    public CommonResponse<ResultCode> checkEmailDuplicate(@RequestParam String email) {
-        userService.validateEmailAvailability(email);
-        return CommonResponse.success(ResultCode.EMAIL_CHECK_SUCCESS); // true : 중복됨
+    @PostMapping("/check-email")
+    public CommonResponse<ResultCode> checkEmailDuplicate(@RequestBody UserEmailCheckRequest request) {
+        userService.validateEmailAvailability(request.email());
+        return CommonResponse.success(ResultCode.EMAIL_CHECK_SUCCESS, null); // true : 중복됨
     }
 
     @Operation(summary = "즐겨찾기 조회", description = "즐겨찾기 목록 조회")

--- a/src/main/java/com/ureca/uhyu/domain/user/service/UserService.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/service/UserService.java
@@ -27,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -43,8 +44,6 @@ public class UserService {
 
     @Transactional
     public Long saveOnboardingInfo(UserOnboardingRequest request, User user) {
-
-        log.info("~~~ saveOnboardingInfo");
 
         user.setUserGrade(request.grade());
         user.setUserRole(UserRole.USER); // TMP_USER → USER 변경

--- a/src/main/java/com/ureca/uhyu/domain/user/service/UserService.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/service/UserService.java
@@ -23,11 +23,13 @@ import com.ureca.uhyu.domain.user.repository.UserRepository;
 import com.ureca.uhyu.global.exception.GlobalException;
 import com.ureca.uhyu.global.response.ResultCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -41,6 +43,8 @@ public class UserService {
 
     @Transactional
     public Long saveOnboardingInfo(UserOnboardingRequest request, User user) {
+
+        log.info("~~~ saveOnboardingInfo");
 
         user.setUserGrade(request.grade());
         user.setUserRole(UserRole.USER); // TMP_USER → USER 변경

--- a/src/main/java/com/ureca/uhyu/global/config/SecurityConfig.java
+++ b/src/main/java/com/ureca/uhyu/global/config/SecurityConfig.java
@@ -120,7 +120,7 @@ public class SecurityConfig {
                         if (authentication != null && authentication.isAuthenticated() && authentication.getAuthorities().stream()
                                 .anyMatch(a -> a.getAuthority().equals("ROLE_TMP_USER"))) {
                             String uri = request.getRequestURI();
-                            if (!uri.equals("/user/extra-info") && !uri.startsWith("/static/")) {
+                            if (!uri.equals("/user/extra-info") && !uri.startsWith("/static/") && !uri.equals("/user/check-email")) {
                                 response.sendRedirect("/user/extra-info");
                                 return;
                             }

--- a/src/main/java/com/ureca/uhyu/global/config/SecurityConfig.java
+++ b/src/main/java/com/ureca/uhyu/global/config/SecurityConfig.java
@@ -109,7 +109,7 @@ public class SecurityConfig {
                 .exceptionHandling(exceptionHandling ->
                     exceptionHandling
                         .accessDeniedHandler((request, response, accessDeniedException) -> {
-                            response.sendRedirect("/extra-info");
+                            response.sendRedirect("/user/extra-info");
                         })
                 )
                 .addFilterAfter(new OncePerRequestFilter() {
@@ -120,8 +120,8 @@ public class SecurityConfig {
                         if (authentication != null && authentication.isAuthenticated() && authentication.getAuthorities().stream()
                                 .anyMatch(a -> a.getAuthority().equals("ROLE_TMP_USER"))) {
                             String uri = request.getRequestURI();
-                            if (!uri.equals("/extra-info") && !uri.startsWith("/static/")) {
-                                response.sendRedirect("/extra-info");
+                            if (!uri.equals("/user/extra-info") && !uri.startsWith("/static/")) {
+                                response.sendRedirect("/user/extra-info");
                                 return;
                             }
                         }
@@ -138,7 +138,7 @@ public class SecurityConfig {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**")
-                        .allowedOrigins("http://localhost:3000")
+                        .allowedOrigins("http://localhost:3000", "http://localhost:5173")
 //                                "https://ixiu.site",
 //                                "https://www.ixiu.site")
                         .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")


### PR DESCRIPTION
## 📌 작업 개요
- 만료된 Jwt 토큰을 재사용하는 에러 수정
- 유저 이메일 중복 확인 기능에 대해 이전에는 get 요청으로 header에 @RequestParam 으로 요청을 보냈었는데, 해당 부분을 post 요청으로 body 에 이메일을 담아 요청하도록 코드를 수정하였습니다.
- 

## ✨ 기타 참고 사항
- 현재 카카오로부터 유저 이메일을 받아, 이후 사용자가 카카오와 동일한 이메일을 입력하고 이메일 중복검사를 하면 당연히 이메일이 중복되었다고 반환될텐데 이 부분 이야기 해봤으면 좋겠습니다.

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.
