### PR TITLE
[FIX][UHYU-159] security swagger 접근 허용

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ureca/uhyu/domain/auth/jwt/JwtAuthenticationFilter.java
@@ -44,6 +44,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
+
+        String uri = request.getRequestURI();
+        if (uri.startsWith("/swagger-ui") || uri.startsWith("/v3/api-docs")) {
+            filterChain.doFilter(request, response); // 토큰 검사 생략
+            return;
+        }
+
         try {
             String accessToken = extractAccessTokenFromCookie(request);
 

--- a/src/main/java/com/ureca/uhyu/global/config/SecurityConfig.java
+++ b/src/main/java/com/ureca/uhyu/global/config/SecurityConfig.java
@@ -85,13 +85,19 @@ public class SecurityConfig {
                                 .requestMatchers( // 인증 없이 접근 허용 : 로그인을 하지 않아도 접근 가능
                                         new AntPathRequestMatcher("/"),
                                         new AntPathRequestMatcher("/map/**"),
-                                        new AntPathRequestMatcher("/brand-list/**")
+                                        new AntPathRequestMatcher("/brand-list/**"),
+                                        new AntPathRequestMatcher("/swagger-ui/**"),
+                                        new AntPathRequestMatcher("/v3/api-docs/**")
                                 ).permitAll()
                                 // ADMIN 권한 필요 : user role이 admin인 사용자만 접근 가능
                                 .requestMatchers(new AntPathRequestMatcher("/admin/**")).hasRole("ADMIN")
                                 // 그 외는 인증 필요 : 로그인한 사용자만 접근 가능
                                 .anyRequest().authenticated()
                 )
+
+//                .authorizeHttpRequests(auth -> auth
+//                        .anyRequest().permitAll()
+//                )
 
                 // oauth2 설정
                 .oauth2Login(oauth2 -> oauth2


### PR DESCRIPTION
## 📌 작업 개요
- Swagger 경로 JWT 필터 예외처리 및 접근 허용 설정
- Swagger UI(`/swagger-ui/**`) 및 OpenAPI 문서(`/v3/api-docs/**`) 경로를 security 설정에서 permitAll로 허용
- JwtAuthenticationFilter에서 해당 경로 요청 시 JWT 검증 생략 처리

## ✨ 기타 참고 사항

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.
