### PR TITLE
[FEAT][UHYU-161] 제휴처 목록 조회 api

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/brand/controller/BrandController.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/controller/BrandController.java
@@ -24,7 +24,7 @@ public class BrandController {
             @RequestParam(required = false) List<String> benefitType,
             @RequestParam(required = false, name = "brand_name") String brandName,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(defaultValue = "3") int size
     ){
         return CommonResponse.success(
                 brandService.findBrands(category, storeType, benefitType, brandName, page, size)

--- a/src/main/java/com/ureca/uhyu/domain/brand/controller/BrandController.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/controller/BrandController.java
@@ -1,0 +1,34 @@
+package com.ureca.uhyu.domain.brand.controller;
+
+import com.ureca.uhyu.domain.brand.dto.response.BrandListRes;
+import com.ureca.uhyu.domain.brand.service.BrandService;
+import com.ureca.uhyu.global.response.CommonResponse;
+import com.ureca.uhyu.global.response.ResultCode;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/brand-list")
+@RequiredArgsConstructor
+public class BrandController {
+
+    public final BrandService brandService;
+
+    @Operation(summary = "제휴처 목록 조회", description = "제휴처 목록 조회, 필터링 적용 가능")
+    @PostMapping
+    public CommonResponse<BrandListRes> getBrands(
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) List<String> tag1,
+            @RequestParam(required = false) List<String> tag2,
+            @RequestParam(required = false, name = "brand_name") String brandName,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ){
+        return CommonResponse.success(
+                brandService.findBrands(category, tag1, tag2, brandName, page, size)
+        );
+    }
+}

--- a/src/main/java/com/ureca/uhyu/domain/brand/controller/BrandController.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/controller/BrandController.java
@@ -3,7 +3,6 @@ package com.ureca.uhyu.domain.brand.controller;
 import com.ureca.uhyu.domain.brand.dto.response.BrandListRes;
 import com.ureca.uhyu.domain.brand.service.BrandService;
 import com.ureca.uhyu.global.response.CommonResponse;
-import com.ureca.uhyu.global.response.ResultCode;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -21,14 +20,14 @@ public class BrandController {
     @PostMapping
     public CommonResponse<BrandListRes> getBrands(
             @RequestParam(required = false) String category,
-            @RequestParam(required = false) List<String> tag1,
-            @RequestParam(required = false) List<String> tag2,
+            @RequestParam(required = false) List<String> storeType,
+            @RequestParam(required = false) List<String> benefitType,
             @RequestParam(required = false, name = "brand_name") String brandName,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ){
         return CommonResponse.success(
-                brandService.findBrands(category, tag1, tag2, brandName, page, size)
+                brandService.findBrands(category, storeType, benefitType, brandName, page, size)
         );
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/brand/dto/response/BrandListRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/dto/response/BrandListRes.java
@@ -1,0 +1,15 @@
+package com.ureca.uhyu.domain.brand.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "즐겨찾기 전체 조회 응답")
+public record BrandListRes (
+        List<BrandRes> brandList,
+        boolean hasNext
+) {
+    public static BrandListRes from(List<BrandRes> brandList,  boolean hasNext) {
+        return new BrandListRes(brandList, hasNext);
+    }
+}

--- a/src/main/java/com/ureca/uhyu/domain/brand/dto/response/BrandListRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/dto/response/BrandListRes.java
@@ -4,12 +4,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
-@Schema(description = "즐겨찾기 전체 조회 응답")
-public record BrandListRes (
+@Schema(description = "제휴처 목록 조회 응답")
+public record BrandListRes(
         List<BrandRes> brandList,
-        boolean hasNext
+        boolean hasNext,
+        int totalPages,
+        int currentPage
 ) {
-    public static BrandListRes from(List<BrandRes> brandList,  boolean hasNext) {
-        return new BrandListRes(brandList, hasNext);
+    public static BrandListRes from(List<BrandRes> list, boolean hasNext, int totalPages, int currentPage) {
+        return new BrandListRes(list, hasNext, totalPages, currentPage);
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/brand/dto/response/BrandPageResult.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/dto/response/BrandPageResult.java
@@ -1,0 +1,11 @@
+package com.ureca.uhyu.domain.brand.dto.response;
+
+import com.ureca.uhyu.domain.brand.entity.Brand;
+
+import java.util.List;
+
+public record BrandPageResult(
+        List<Brand> brandList,
+        long totalCount
+) {
+}

--- a/src/main/java/com/ureca/uhyu/domain/brand/dto/response/BrandRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/dto/response/BrandRes.java
@@ -11,13 +11,16 @@ public record BrandRes (
 ){
     public static BrandRes from(Brand brand){
         // TODO : 혜택 어떻게 꺼내올지 아직 고민중 (전부 다 가져와야하나?)
-        Benefit benefit = brand.getBenefits().get(0);
+        String description = brand.getBenefits().stream()
+                .findFirst()
+                .map(Benefit::getDescription)
+                .orElse(null);
 
         return new BrandRes(
                 brand.getId(),
                 brand.getBrandName(),
                 brand.getLogoImage(),
-                benefit.getDescription()
+                description
         );
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/brand/dto/response/BrandRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/dto/response/BrandRes.java
@@ -1,0 +1,23 @@
+package com.ureca.uhyu.domain.brand.dto.response;
+
+import com.ureca.uhyu.domain.brand.entity.Benefit;
+import com.ureca.uhyu.domain.brand.entity.Brand;
+
+public record BrandRes (
+        Long brandId,
+        String brandName,
+        String logoImage,
+        String description
+){
+    public static BrandRes from(Brand brand){
+        // TODO : 혜택 어떻게 꺼내올지 아직 고민중 (전부 다 가져와야하나?)
+        Benefit benefit = brand.getBenefits().get(0);
+
+        return new BrandRes(
+                brand.getId(),
+                brand.getBrandName(),
+                brand.getLogoImage(),
+                benefit.getDescription()
+        );
+    }
+}

--- a/src/main/java/com/ureca/uhyu/domain/brand/entity/Benefit.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/entity/Benefit.java
@@ -1,5 +1,6 @@
 package com.ureca.uhyu.domain.brand.entity;
 
+import com.ureca.uhyu.domain.brand.enums.BenefitType;
 import com.ureca.uhyu.domain.user.enums.Grade;
 import com.ureca.uhyu.global.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -17,6 +18,9 @@ public class Benefit extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private Grade grade;
+
+    @Enumerated(EnumType.STRING)
+    private BenefitType benefitType;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "brand_id")

--- a/src/main/java/com/ureca/uhyu/domain/brand/enums/BenefitType.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/enums/BenefitType.java
@@ -1,0 +1,6 @@
+package com.ureca.uhyu.domain.brand.enums;
+
+public enum BenefitType {
+    DISCOUNT,
+    GIFT
+}

--- a/src/main/java/com/ureca/uhyu/domain/brand/repository/BrandRepository.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/repository/BrandRepository.java
@@ -7,7 +7,8 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface BrandRepository extends JpaRepository<Brand, Long> {
+public interface BrandRepository extends JpaRepository<Brand, Long>
+        , BrandRepositoryCustom{
 
     List<Brand> findByBrandNameIn(List<String> brandNames);
 

--- a/src/main/java/com/ureca/uhyu/domain/brand/repository/BrandRepositoryCustom.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/repository/BrandRepositoryCustom.java
@@ -6,9 +6,9 @@ import java.util.List;
 
 public interface BrandRepositoryCustom {
     public BrandPageResult findByCategoryOrNameOrTypes(String category,
-                                                       String brandName,
                                                        List<String> storeType,
                                                        List<String> benefitType,
+                                                       String brandName,
                                                        int page,
                                                        int size);
 }

--- a/src/main/java/com/ureca/uhyu/domain/brand/repository/BrandRepositoryCustom.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/repository/BrandRepositoryCustom.java
@@ -1,14 +1,14 @@
 package com.ureca.uhyu.domain.brand.repository;
 
-import com.ureca.uhyu.domain.brand.entity.Brand;
+import com.ureca.uhyu.domain.brand.dto.response.BrandPageResult;
 
 import java.util.List;
 
 public interface BrandRepositoryCustom {
-    public List<Brand> findByCategoryOrNameOrTypes(String category,
-                                                   String brandName,
-                                                   List<String> storeType,
-                                                   List<String> benefitType,
-                                                   int page,
-                                                   int size);
+    public BrandPageResult findByCategoryOrNameOrTypes(String category,
+                                                       String brandName,
+                                                       List<String> storeType,
+                                                       List<String> benefitType,
+                                                       int page,
+                                                       int size);
 }

--- a/src/main/java/com/ureca/uhyu/domain/brand/repository/BrandRepositoryCustom.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/repository/BrandRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.ureca.uhyu.domain.brand.repository;
+
+import com.ureca.uhyu.domain.brand.entity.Brand;
+
+import java.util.List;
+
+public interface BrandRepositoryCustom {
+    public List<Brand> findByCategoryOrNameOrTypes(String category,
+                                                   String brandName,
+                                                   List<String> storeType,
+                                                   List<String> benefitType,
+                                                   int page,
+                                                   int size);
+}

--- a/src/main/java/com/ureca/uhyu/domain/brand/repository/BrandRepositoryCustomImpl.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/repository/BrandRepositoryCustomImpl.java
@@ -26,9 +26,9 @@ public class BrandRepositoryCustomImpl implements BrandRepositoryCustom {
 
     @Override
     public BrandPageResult findByCategoryOrNameOrTypes(String category,
-                                                       String brandName,
                                                        List<String> storeType,
                                                        List<String> benefitType,
+                                                       String brandName,
                                                        int page,
                                                        int size) {
 

--- a/src/main/java/com/ureca/uhyu/domain/brand/repository/BrandRepositoryCustomImpl.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/repository/BrandRepositoryCustomImpl.java
@@ -1,0 +1,76 @@
+package com.ureca.uhyu.domain.brand.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ureca.uhyu.domain.brand.entity.Brand;
+import com.ureca.uhyu.domain.brand.entity.QBenefit;
+import com.ureca.uhyu.domain.brand.entity.QBrand;
+import com.ureca.uhyu.domain.brand.entity.QCategory;
+import com.ureca.uhyu.domain.brand.enums.BenefitType;
+import com.ureca.uhyu.domain.brand.enums.StoreType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class BrandRepositoryCustomImpl implements BrandRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Brand> findByCategoryOrNameOrTypes(String category,
+                                                   String brandName,
+                                                   List<String> storeType,
+                                                   List<String> benefitType,
+                                                   int page,
+                                                   int size) {
+
+        QBrand brand = QBrand.brand;
+        QCategory categoryEntity = QCategory.category;
+        QBenefit benefit = QBenefit.benefit;
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (StringUtils.hasText(brandName)) {
+            builder.and(brand.brandName.containsIgnoreCase(brandName));
+        }
+
+        if (StringUtils.hasText(category) && !"all".equalsIgnoreCase(category)) {
+            builder.and(brand.category.categoryName.eq(category));
+        }
+
+        if (storeType != null && !storeType.isEmpty()) {
+            List<StoreType> storeTypes = storeType.stream()
+                    .map(String::toUpperCase)
+                    .map(StoreType::valueOf)
+                    .toList();
+            builder.and(brand.storeType.in(storeTypes));
+        }
+
+        //TODO : 빌드하려고 임시로 빨간줄만 안뜨게 만듦, 수정 예정
+//        if (benefitType!= null && !benefitType.isEmpty()) {
+//            List<BenefitType> benefitTypes = benefitType.stream()
+//                    .map(String::toUpperCase)
+//                    .map(BenefitType::valueOf)
+//                    .toList();
+//            builder.and(benefit.benefitType.in(benefitTypes));
+//        }
+
+        Pageable pageable = PageRequest.of(page, size);
+
+        return queryFactory
+                .selectFrom(brand)
+                .distinct()
+                .join(brand.category, categoryEntity)
+                .leftJoin(brand.benefits, benefit)
+                .where(builder)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+}

--- a/src/main/java/com/ureca/uhyu/domain/brand/repository/BrandRepositoryCustomImpl.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/repository/BrandRepositoryCustomImpl.java
@@ -2,6 +2,7 @@ package com.ureca.uhyu.domain.brand.repository;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ureca.uhyu.domain.brand.dto.response.BrandPageResult;
 import com.ureca.uhyu.domain.brand.entity.Brand;
 import com.ureca.uhyu.domain.brand.entity.QBenefit;
 import com.ureca.uhyu.domain.brand.entity.QBrand;
@@ -15,20 +16,21 @@ import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
-public class BrandRepositoryCustomImpl implements BrandRepositoryCustom{
+public class BrandRepositoryCustomImpl implements BrandRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<Brand> findByCategoryOrNameOrTypes(String category,
-                                                   String brandName,
-                                                   List<String> storeType,
-                                                   List<String> benefitType,
-                                                   int page,
-                                                   int size) {
+    public BrandPageResult findByCategoryOrNameOrTypes(String category,
+                                                       String brandName,
+                                                       List<String> storeType,
+                                                       List<String> benefitType,
+                                                       int page,
+                                                       int size) {
 
         QBrand brand = QBrand.brand;
         QCategory categoryEntity = QCategory.category;
@@ -36,14 +38,17 @@ public class BrandRepositoryCustomImpl implements BrandRepositoryCustom{
 
         BooleanBuilder builder = new BooleanBuilder();
 
+        // 브랜드 이름 조건
         if (StringUtils.hasText(brandName)) {
             builder.and(brand.brandName.containsIgnoreCase(brandName));
         }
 
+        // 카테고리 조건
         if (StringUtils.hasText(category) && !"all".equalsIgnoreCase(category)) {
             builder.and(brand.category.categoryName.eq(category));
         }
 
+        // 매장 타입 필터
         if (storeType != null && !storeType.isEmpty()) {
             List<StoreType> storeTypes = storeType.stream()
                     .map(String::toUpperCase)
@@ -52,18 +57,29 @@ public class BrandRepositoryCustomImpl implements BrandRepositoryCustom{
             builder.and(brand.storeType.in(storeTypes));
         }
 
-        //TODO : 빌드하려고 임시로 빨간줄만 안뜨게 만듦, 수정 예정
-//        if (benefitType!= null && !benefitType.isEmpty()) {
-//            List<BenefitType> benefitTypes = benefitType.stream()
-//                    .map(String::toUpperCase)
-//                    .map(BenefitType::valueOf)
-//                    .toList();
-//            builder.and(benefit.benefitType.in(benefitTypes));
-//        }
+        // 혜택 타입 필터
+        if (benefitType != null && !benefitType.isEmpty()) {
+            List<BenefitType> benefitTypes = benefitType.stream()
+                    .map(String::toUpperCase)
+                    .map(BenefitType::valueOf)
+                    .toList();
+            builder.and(benefit.benefitType.in(benefitTypes));
+        }
 
         Pageable pageable = PageRequest.of(page, size);
 
-        return queryFactory
+        // 전체 개수 조회
+        Long count = queryFactory
+                .select(brand.countDistinct())
+                .from(brand)
+                .join(brand.category, categoryEntity)
+                .leftJoin(brand.benefits, benefit)
+                .where(builder)
+                .fetchOne();
+        long totalCount = Optional.ofNullable(count).orElse(0L);
+
+        // 결과 리스트 조회
+        List<Brand> result = queryFactory
                 .selectFrom(brand)
                 .distinct()
                 .join(brand.category, categoryEntity)
@@ -72,5 +88,7 @@ public class BrandRepositoryCustomImpl implements BrandRepositoryCustom{
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
+
+        return new BrandPageResult(result, totalCount);
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/brand/service/BrandService.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/service/BrandService.java
@@ -3,9 +3,7 @@ package com.ureca.uhyu.domain.brand.service;
 import com.ureca.uhyu.domain.brand.dto.response.BrandListRes;
 import com.ureca.uhyu.domain.brand.dto.response.BrandPageResult;
 import com.ureca.uhyu.domain.brand.dto.response.BrandRes;
-import com.ureca.uhyu.domain.brand.entity.Brand;
 import com.ureca.uhyu.domain.brand.repository.BrandRepository;
-import com.ureca.uhyu.domain.user.dto.response.BookmarkRes;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -22,7 +20,7 @@ public class BrandService {
     public BrandListRes findBrands(String category, List<String> storeType, List<String> benefitType,
                                    String brandName, int page, int size) {
         BrandPageResult result = brandRepository.findByCategoryOrNameOrTypes(
-                category, brandName, storeType, benefitType, page, size
+                category, storeType, benefitType, brandName, page, size
         );
 
         List<BrandRes> brandList = result.brandList().stream()

--- a/src/main/java/com/ureca/uhyu/domain/brand/service/BrandService.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/service/BrandService.java
@@ -1,0 +1,32 @@
+package com.ureca.uhyu.domain.brand.service;
+
+import com.ureca.uhyu.domain.brand.dto.response.BrandListRes;
+import com.ureca.uhyu.domain.brand.dto.response.BrandRes;
+import com.ureca.uhyu.domain.brand.entity.Brand;
+import com.ureca.uhyu.domain.brand.repository.BrandRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BrandService {
+
+    private final BrandRepository brandRepository;
+
+    public BrandListRes findBrands(String category, List<String> tag1, List<String> tag2, String brandName, int page, int size) {
+        List<Brand> brand = brandRepository.findByCategoryOrNameOrTypes(category, brandName, tag1, tag2, page, size);
+        List<BrandRes> brandList = new ArrayList<>();
+        for(Brand b : brand){
+            brandList.add(BrandRes.from(b));
+        }
+
+        //TODO : 빌드하려고 임시로 빨간줄만 안뜨게 만듦, 수정 예정
+        boolean hasNext = brandList.size() < size;
+        return BrandListRes.from(brandList, hasNext);
+    }
+}

--- a/src/main/java/com/ureca/uhyu/domain/brand/service/BrandService.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/service/BrandService.java
@@ -1,14 +1,15 @@
 package com.ureca.uhyu.domain.brand.service;
 
 import com.ureca.uhyu.domain.brand.dto.response.BrandListRes;
+import com.ureca.uhyu.domain.brand.dto.response.BrandPageResult;
 import com.ureca.uhyu.domain.brand.dto.response.BrandRes;
 import com.ureca.uhyu.domain.brand.entity.Brand;
 import com.ureca.uhyu.domain.brand.repository.BrandRepository;
+import com.ureca.uhyu.domain.user.dto.response.BookmarkRes;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -18,15 +19,20 @@ public class BrandService {
 
     private final BrandRepository brandRepository;
 
-    public BrandListRes findBrands(String category, List<String> tag1, List<String> tag2, String brandName, int page, int size) {
-        List<Brand> brand = brandRepository.findByCategoryOrNameOrTypes(category, brandName, tag1, tag2, page, size);
-        List<BrandRes> brandList = new ArrayList<>();
-        for(Brand b : brand){
-            brandList.add(BrandRes.from(b));
-        }
+    public BrandListRes findBrands(String category, List<String> storeType, List<String> benefitType,
+                                   String brandName, int page, int size) {
+        BrandPageResult result = brandRepository.findByCategoryOrNameOrTypes(
+                category, brandName, storeType, benefitType, page, size
+        );
 
-        //TODO : 빌드하려고 임시로 빨간줄만 안뜨게 만듦, 수정 예정
-        boolean hasNext = brandList.size() < size;
-        return BrandListRes.from(brandList, hasNext);
+        List<BrandRes> brandList = result.brandList().stream()
+                .map(BrandRes::from)
+                .toList();
+
+        long totalCount = result.totalCount();
+        int totalPages = (int) Math.ceil((double) totalCount / size);
+        boolean hasNext = page + 1 < totalPages;
+
+        return BrandListRes.from(brandList, hasNext, totalPages, page);
     }
 }

--- a/src/main/resources/db/changelog/2025/07/15-01-changelog.xml
+++ b/src/main/resources/db/changelog/2025/07/15-01-changelog.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.29.xsd"
+        objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+    <changeSet id="1752560212760-1" author="student">
+        <addColumn tableName="benefit">
+            <column name="benefit_type" type="VARCHAR(255)"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/com/ureca/uhyu/domain/brand/service/BrandServiceTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/brand/service/BrandServiceTest.java
@@ -1,0 +1,160 @@
+package com.ureca.uhyu.domain.brand.service;
+
+import com.ureca.uhyu.domain.brand.dto.response.BrandListRes;
+import com.ureca.uhyu.domain.brand.dto.response.BrandPageResult;
+import com.ureca.uhyu.domain.brand.entity.Benefit;
+import com.ureca.uhyu.domain.brand.entity.Brand;
+import com.ureca.uhyu.domain.brand.entity.Category;
+import com.ureca.uhyu.domain.brand.enums.StoreType;
+import com.ureca.uhyu.domain.brand.repository.BrandRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BrandServiceTest {
+
+    @Mock
+    private BrandRepository brandRepository;
+
+    @InjectMocks
+    private BrandService brandService;
+
+    @DisplayName("제휴처 목록 조회 - 다음 페이지 존재(페이지네이션 검증)")
+    @Test
+    void findBrands_hasNextTrue() {
+        // given
+        String category = "카페";
+        List<String> storeTypes = List.of("ONLINE", "OFFLINE");
+        List<String> benefitTypes = List.of("DISCOUNT", "GIFT");
+        String brandName = "이디야";
+        int page = 0;
+        int size = 2;                   // 1 페이지당 2개씩
+
+        Brand brand1 = createBrand("이디야", "logo_A.png");
+        Brand brand2 = createBrand("브랜드 B", "logo_B.png");
+        setId(brand1, 1L);
+        setId(brand2, 2L);
+
+        List<Brand> brandList = List.of(brand1, brand2);
+        long totalCount = 5L; 
+
+        BrandPageResult mockResult = new BrandPageResult(brandList, totalCount);
+
+        // mock
+        when(brandRepository.findByCategoryOrNameOrTypes(category, storeTypes, benefitTypes, brandName, page, size))
+                .thenReturn(mockResult);
+
+        // when
+        BrandListRes result = brandService.findBrands(category, storeTypes, benefitTypes, brandName, page, size);
+
+        // then
+        assertEquals(2, result.brandList().size());
+        assertEquals(3, result.totalPages());
+        assertEquals(brandName, result.brandList().get(0).brandName());
+        assertEquals(page, result.currentPage());
+        assertTrue(result.hasNext());
+    }
+
+    @DisplayName("브랜드 목록 조회 - 마지막 페이지(페이지네이션 검증)")
+    @Test
+    void findBrands_hasNextFalse() {
+        // given
+        String category = "카페";
+        List<String> storeTypes = List.of("ONLINE");
+        List<String> benefitTypes = List.of("DISCOUNT");
+        String brandName = null;
+        int page = 1;
+        int size = 2;
+
+        Brand brand1 = createBrand("이디야", "logo_A.png");
+        setId(brand1, 3L);
+        List<Brand> brandList = List.of(brand1); // 마지막 페이지에 1건만
+
+        long totalCount = 3L;
+
+        BrandPageResult mockResult = new BrandPageResult(brandList, totalCount);
+
+        // mock
+        when(brandRepository.findByCategoryOrNameOrTypes(category, storeTypes, benefitTypes, brandName, page, size))
+                .thenReturn(mockResult);
+
+        // when
+        BrandListRes result = brandService.findBrands(category, storeTypes, benefitTypes, brandName, page, size);
+
+        // then
+        assertEquals(1, result.brandList().size());
+        assertEquals(2, result.totalPages()); // (int) ceil(3 / 2) = 2
+        assertFalse(result.hasNext());
+        assertEquals(page, result.currentPage());
+    }
+
+    @DisplayName("브랜드 목록 조회 - 결과 없음")
+    @Test
+    void findBrands_emptyResult() {
+        // given
+        String category = "뷰티";
+        List<String> storeTypes = List.of("ONLINE");
+        List<String> benefitTypes = List.of("DISCOUNT");
+        String brandName = "없는브랜드";
+        int page = 0;
+        int size = 10;
+
+        BrandPageResult mockResult = new BrandPageResult(List.of(), 0L);
+
+        // mock
+        when(brandRepository.findByCategoryOrNameOrTypes(category, storeTypes, benefitTypes, brandName, page, size))
+                .thenReturn(mockResult);
+
+        // when
+        BrandListRes result = brandService.findBrands(category, storeTypes, benefitTypes, brandName, page, size);
+
+        // then
+        assertTrue(result.brandList().isEmpty());
+        assertEquals(0, result.totalPages());
+        assertFalse(result.hasNext());
+        assertEquals(page, result.currentPage());
+    }
+
+    private Brand createBrand(String name, String image) {
+        Category category = Category.builder()
+                .categoryName("카페")
+                .build();
+        setId(category, 1L);
+
+        Benefit benefit = Benefit.builder()
+                .description("혜택1")
+                .build();
+        setId(benefit, 2L);
+
+        Brand brand = Brand.builder()
+                .category(category)
+                .brandName(name)
+                .logoImage(image)
+                .usageMethod("모바일 바코드 제시")
+                .usageLimit("1일 1회")
+                .storeType(StoreType.OFFLINE)
+                .benefits(List.of(benefit))
+                .build();
+        return brand;
+    }
+
+    private void setId(Object target, Long idValue) {
+        try {
+            Field idField = target.getClass().getSuperclass().getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(target, idValue);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 제휴처 목록 조회 기능 구현
- 카테고리, 이용 타입, 혜택 종류, 브랜드 명 등을 통한 필터링 기능 추가
- 동적 쿼리를 위해 QueryDSL을 사용하여 기능을 구현
- 페이지네이션 적용 (1페이지당 3개정도 보이도록 기본값 설정)
- 기능 검증을 위한 단위 테스트 코드 작성

## ✨ 기타 참고 사항
<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 

## ✅ PR 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [ ] 로컬 서버에서 정상 동작을 확인했어요.
- [ ] 불필요한 코드/주석 삭제했어요.
