### PR TITLE
[FEAT][UHYU-169] 사용자 활동 내역 기능 확장

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/user/dto/response/RecentStoreListRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/dto/response/RecentStoreListRes.java
@@ -1,0 +1,17 @@
+package com.ureca.uhyu.domain.user.dto.response;
+
+import com.ureca.uhyu.domain.store.entity.Store;
+
+public record RecentStoreListRes(
+        Long recentStoreId,
+        String recentStoreName,
+        String recentBrandImage
+) {
+    public static RecentStoreListRes from(Store store) {
+        return new RecentStoreListRes(
+                store.getId(),
+                store.getName(),
+                store.getBrand().getLogoImage()
+        );
+    }
+}

--- a/src/main/java/com/ureca/uhyu/domain/user/dto/response/UserStatisticsRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/dto/response/UserStatisticsRes.java
@@ -1,7 +1,5 @@
 package com.ureca.uhyu.domain.user.dto.response;
 
-import com.ureca.uhyu.domain.user.entity.ActionLogs;
-import com.ureca.uhyu.domain.user.entity.History;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;

--- a/src/main/java/com/ureca/uhyu/domain/user/dto/response/UserStatisticsRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/dto/response/UserStatisticsRes.java
@@ -9,12 +9,18 @@ import java.util.List;
 @Schema(description = "유저 활동내역 응답")
 public record UserStatisticsRes(
         Integer discountMoney,
-        List<BestBrandListRes> bestBrandList
+        List<BestBrandListRes> bestBrandList,
+        List<RecentStoreListRes> recentStoreList
 ) {
-    public static UserStatisticsRes from(Integer discountMoney, List<BestBrandListRes> bestBrandList) {
+    public static UserStatisticsRes from(
+            Integer discountMoney,
+            List<BestBrandListRes> bestBrandList,
+            List<RecentStoreListRes> recentStoreList
+    ) {
         return new UserStatisticsRes(
                 discountMoney,
-                bestBrandList
+                bestBrandList,
+                recentStoreList
         );
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/user/repository/HistoryRepositoryCustom.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/repository/HistoryRepositoryCustom.java
@@ -1,7 +1,11 @@
 package com.ureca.uhyu.domain.user.repository;
 
+import com.ureca.uhyu.domain.store.entity.Store;
 import com.ureca.uhyu.domain.user.entity.User;
+
+import java.util.List;
 
 public interface HistoryRepositoryCustom {
     Integer findDiscountMoneyThisMonth(User user);
+    List<Store> findTop3RecentStore(User user);
 }

--- a/src/main/java/com/ureca/uhyu/domain/user/repository/HistoryRepositoryCustomImpl.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/repository/HistoryRepositoryCustomImpl.java
@@ -1,6 +1,8 @@
 package com.ureca.uhyu.domain.user.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ureca.uhyu.domain.store.entity.QStore;
+import com.ureca.uhyu.domain.store.entity.Store;
 import com.ureca.uhyu.domain.user.entity.QHistory;
 import com.ureca.uhyu.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +10,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -30,5 +33,19 @@ public class HistoryRepositoryCustomImpl implements HistoryRepositoryCustom{
                         history.visitedAt.between(start, end)
                 )
                 .fetchOne();
+    }
+
+    public List<Store> findTop3RecentStore(User user) {
+        QHistory history = QHistory.history;
+        QStore store = QStore.store;
+
+        return queryFactory
+                .select(store)
+                .from(history)
+                .join(store).on(history.store.eq(QStore.store))
+                .where(history.user.eq(user))
+                .orderBy(history.visitedAt.desc())
+                .limit(3)
+                .fetch();
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/user/service/UserService.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/service/UserService.java
@@ -5,6 +5,7 @@ import com.ureca.uhyu.domain.brand.repository.BrandRepository;
 import com.ureca.uhyu.domain.recommendation.entity.RecommendationBaseData;
 import com.ureca.uhyu.domain.recommendation.enums.DataType;
 import com.ureca.uhyu.domain.recommendation.repository.RecommendationBaseDataRepository;
+import com.ureca.uhyu.domain.store.entity.Store;
 import com.ureca.uhyu.domain.user.dto.request.UpdateUserReq;
 import com.ureca.uhyu.domain.user.dto.request.UserOnboardingRequest;
 import com.ureca.uhyu.domain.user.dto.response.*;
@@ -34,6 +35,7 @@ public class UserService {
     private final BookmarkRepository bookmarkRepository;
     private final HistoryRepository historyRepository;
     private final ActionLogsRepository actionLogsRepository;
+
 
     @Transactional
     public Long saveOnboardingInfo(UserOnboardingRequest request, User user) {
@@ -145,6 +147,10 @@ public class UserService {
         List<BestBrandListRes> bestBrandListRes = brands.stream()
                 .map(BestBrandListRes::from)
                 .toList();
-        return UserStatisticsRes.from(discountMoney, bestBrandListRes);
+        List<Store> stores = historyRepository.findTop3RecentStore(user);
+        List<RecentStoreListRes> recentStoreListRes = stores.stream()
+                .map(RecentStoreListRes::from)
+                .toList();
+        return UserStatisticsRes.from(discountMoney, bestBrandListRes, recentStoreListRes);
     }
 }

--- a/src/test/java/com/ureca/uhyu/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/user/service/UserServiceTest.java
@@ -204,7 +204,7 @@ class UserServiceTest {
         Brand brand = createBrand("브랜드A", "logo.png");
         setId(brand, 20L);
 
-        Store store = createStore(brand);
+        Store store = createStore(brand, "스토어A", "서울시 마포구");
         setId(store, 30L);
 
         Bookmark bookmark = createBookmark(bookmarkList, store);
@@ -244,7 +244,7 @@ class UserServiceTest {
         Brand brand = createBrand("브랜드A", "logo.png");
         setId(brand, 20L);
 
-        Store store = createStore(brand);
+        Store store = createStore(brand, "매장 A", "경기도 고양시");
         setId(store, 30L);
 
         Bookmark bookmark = createBookmark(bookmarkList, store);
@@ -276,7 +276,7 @@ class UserServiceTest {
         Brand brand = createBrand("브랜드A", "logo.png");
         setId(brand, 20L);
 
-        Store store = createStore(brand);
+        Store store = createStore(brand, "매장A", "경기도 고양시");
         setId(store, 30L);
 
         Bookmark bookmark = createBookmark(bookmarkList, store);
@@ -322,6 +322,7 @@ class UserServiceTest {
 
         Integer discountMoney = 12345;
 
+        // 가장 많이 조회한 브랜드
         Brand brand1 = createBrand("브랜드A", "logo1.png");
         Brand brand2 = createBrand("브랜드B", "logo2.png");
         Brand brand3 = createBrand("브랜드C", "logo3.png");
@@ -333,9 +334,20 @@ class UserServiceTest {
 
         List<Brand> topBrands = List.of(brand2, brand4, brand1);
 
+        // 가장 최근 방문 매장
+        Store store1 = createStore(brand1, "스토어1", "서울시 강남구");
+        Store store2 = createStore(brand2, "스토어2", "서울시 마포구");
+        Store store3 = createStore(brand3, "스토어3", "서울시 종로구");
+        setId(store1, 11L);
+        setId(store2, 12L);
+        setId(store3, 13L);
+
+        List<Store> recentStores = List.of(store1, store2, store3);
+
         // mock
         when(historyRepository.findDiscountMoneyThisMonth(user)).thenReturn(discountMoney);
         when(actionLogsRepository.findTop3ClickedBrands(user)).thenReturn(topBrands);
+        when(historyRepository.findTop3RecentStore(user)).thenReturn(recentStores);
 
         // when
         UserStatisticsRes result = userService.findUserStatistics(user);
@@ -343,6 +355,7 @@ class UserServiceTest {
         // then
         assertEquals(discountMoney, result.discountMoney());
 
+        // 가장 많이 조회한 브랜드
         assertEquals(3, result.bestBrandList().size());
 
         assertEquals(2, result.bestBrandList().get(0).bestBrandId());
@@ -356,6 +369,21 @@ class UserServiceTest {
         assertEquals(1, result.bestBrandList().get(2).bestBrandId());
         assertEquals("브랜드A", result.bestBrandList().get(2).bestBrandName());
         assertEquals("logo1.png", result.bestBrandList().get(2).bestBrandImage());
+
+        // 가장 최근 방문 매장
+        assertEquals(3, result.recentStoreList().size());
+
+        assertEquals(11L, result.recentStoreList().get(0).recentStoreId());
+        assertEquals("스토어1", result.recentStoreList().get(0).recentStoreName());
+        assertEquals("logo1.png", result.recentStoreList().get(0).recentBrandImage());
+
+        assertEquals(12L, result.recentStoreList().get(1).recentStoreId());
+        assertEquals("스토어2", result.recentStoreList().get(1).recentStoreName());
+        assertEquals("logo2.png", result.recentStoreList().get(1).recentBrandImage());
+
+        assertEquals(13L, result.recentStoreList().get(2).recentStoreId());
+        assertEquals("스토어3", result.recentStoreList().get(2).recentStoreName());
+        assertEquals("logo3.png", result.recentStoreList().get(2).recentBrandImage());
     }
 
     private User createUser() {
@@ -408,10 +436,10 @@ class UserServiceTest {
         return brand;
     }
 
-    private Store createStore(Brand brand) {
+    private Store createStore(Brand brand, String name, String address) {
         Store store = Store.builder()
-                .name("스토어A")
-                .addrDetail("서울시 마포구")
+                .name(name)
+                .addrDetail(address)
                 .geom(null)  // 필요시 값 넣어두기
                 .brand(brand)
                 .build();


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 프론트의 요청에 따라 할인 금액 + 가장 많이 조회한 브랜드 top3 에서 최근 방문한 매장 top3도 볼 수 있도록 추가하였습니다.
- 관련 내용 검증을 위한 테스트 코드 추가하였습니다.

## ✨ 기타 참고 사항
<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- ***다만 최근 방문 매장 top3에서 같은 매장을 여러번 방문 했다면 중복된 만큼 갯수가 생략됨. (ex. 최근 방문 매장이 상암동 스타벅스, 상암동 스타벅스, 고양시 스타벅스인 경우, [상암동 스타벅스, 고양시 스타벅스]만 출력되고 있음. QueryDSL이 아닌 Native Query를 사용해아하는 것은 아닌지 논의가 필요.***

## ✅ PR 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [ ] 로컬 서버에서 정상 동작을 확인했어요.
- [ ] 불필요한 코드/주석 삭제했어요.
