### PR TITLE
[FEAT][UHYU-179] My Map 추가

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/mymap/controller/MyMapController.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/controller/MyMapController.java
@@ -1,5 +1,6 @@
 package com.ureca.uhyu.domain.mymap.controller;
 
+import com.ureca.uhyu.domain.mymap.dto.request.MyMapReq;
 import com.ureca.uhyu.domain.mymap.dto.response.MyMapRes;
 import com.ureca.uhyu.domain.mymap.service.MyMapService;
 import com.ureca.uhyu.domain.user.entity.User;
@@ -7,9 +8,7 @@ import com.ureca.uhyu.global.annotation.CurrentUser;
 import com.ureca.uhyu.global.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -20,9 +19,15 @@ public class MyMapController {
 
     private final MyMapService myMapService;
 
-    @Operation(summary = "mymap 조회", description = "어느 MyMap에 저장할지 정하기 위해 목록 조회, 즐겨찾기는 프론트쪽에서 버튼만 만들기")
+    @Operation(summary = "My Map 조회", description = "어느 My Map에 저장할지 정하기 위해 목록 조회, 즐겨찾기는 프론트쪽에서 버튼만 만들기")
     @GetMapping("/list")
     public CommonResponse<List<MyMapRes>> getMyMapList(@CurrentUser User user){
         return CommonResponse.success(myMapService.findMyMapList(user));
+    }
+
+    @Operation(summary = "My Map 추가", description = "사용자가 새로운 My Map을 생성")
+    @PostMapping
+    public CommonResponse<Long> createMyMapList(@CurrentUser User user, @RequestBody MyMapReq myMapReq){
+        return CommonResponse.success(myMapService.createMyMapList(user, myMapReq));
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/mymap/dto/request/MyMapReq.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/dto/request/MyMapReq.java
@@ -1,0 +1,21 @@
+package com.ureca.uhyu.domain.mymap.dto.request;
+
+import com.ureca.uhyu.domain.mymap.entity.MyMap;
+import com.ureca.uhyu.domain.mymap.entity.MyMapList;
+import com.ureca.uhyu.domain.mymap.enums.MarkerColor;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "My Map 생성 요청 DTO")
+public record MyMapReq(
+        String title,
+        MarkerColor markerColor,
+        String uuid
+) {
+    public static MyMapReq from(MyMapList myMapList){
+        return new  MyMapReq(
+                myMapList.getTitle(),
+                myMapList.getMarkerColor(),
+                myMapList.getUuid()
+        );
+    }
+}

--- a/src/main/java/com/ureca/uhyu/domain/mymap/dto/request/MyMapReq.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/dto/request/MyMapReq.java
@@ -1,6 +1,5 @@
 package com.ureca.uhyu.domain.mymap.dto.request;
 
-import com.ureca.uhyu.domain.mymap.entity.MyMap;
 import com.ureca.uhyu.domain.mymap.entity.MyMapList;
 import com.ureca.uhyu.domain.mymap.enums.MarkerColor;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/ureca/uhyu/domain/mymap/dto/response/MyMapRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/dto/response/MyMapRes.java
@@ -4,7 +4,7 @@ import com.ureca.uhyu.domain.mymap.entity.MyMapList;
 import com.ureca.uhyu.domain.mymap.enums.MarkerColor;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "MyMap 목록 조회 응답 DTO")
+@Schema(description = "My Map 목록 조회 응답 DTO")
 public record MyMapRes(
         Long myMapListId,
         String title,

--- a/src/main/java/com/ureca/uhyu/domain/mymap/entity/MyMapList.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/entity/MyMapList.java
@@ -1,7 +1,6 @@
 package com.ureca.uhyu.domain.mymap.entity;
 
 import com.ureca.uhyu.domain.mymap.enums.MarkerColor;
-import com.ureca.uhyu.domain.mymap.enums.Visibility;
 import com.ureca.uhyu.domain.user.entity.User;
 import com.ureca.uhyu.global.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -18,19 +17,12 @@ public class MyMapList extends BaseEntity {
     @Column(length = 30, nullable = false)
     private String title;
 
-    @Column(name = "description", nullable = false)
-    private String description;
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private MarkerColor markerColor;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private Visibility visibility;
-
     @Column(name = "uuid", nullable = false)
-    private Long uuid;
+    private String uuid;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/java/com/ureca/uhyu/domain/mymap/enums/Visibility.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/enums/Visibility.java
@@ -1,7 +1,0 @@
-package com.ureca.uhyu.domain.mymap.enums;
-
-public enum Visibility {
-    PUBLIC,
-    LINK,
-    PRIVATE
-}

--- a/src/main/java/com/ureca/uhyu/domain/mymap/service/MyMapService.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/service/MyMapService.java
@@ -1,9 +1,11 @@
 package com.ureca.uhyu.domain.mymap.service;
 
+import com.ureca.uhyu.domain.mymap.dto.request.MyMapReq;
 import com.ureca.uhyu.domain.mymap.dto.response.MyMapRes;
 import com.ureca.uhyu.domain.mymap.entity.MyMapList;
 import com.ureca.uhyu.domain.mymap.repository.MyMapListRepository;
 import com.ureca.uhyu.domain.user.entity.User;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -22,5 +24,18 @@ public class MyMapService {
         return myMapLists.stream()
                 .map(MyMapRes::from)
                 .toList();
+    }
+
+    @Transactional
+    public Long createMyMapList(User user,  MyMapReq myMapReq) {
+        MyMapList myMapList = MyMapList.builder()
+                .title(myMapReq.title())
+                .markerColor(myMapReq.markerColor())
+                .uuid(myMapReq.uuid())
+                .user(user)
+                .build();
+        MyMapList savedMyMapList = myMapListRepository.save(myMapList);
+
+        return savedMyMapList.getId();
     }
 }

--- a/src/main/resources/db/changelog/2025/07/18-03-changelog.xml
+++ b/src/main/resources/db/changelog/2025/07/18-03-changelog.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.29.xsd"
+        objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+    <changeSet id="1752823676768-4" author="student">
+        <dropColumn columnName="description" tableName="my_map_list"/>
+
+        <dropColumn columnName="visibility" tableName="my_map_list"/>
+
+        <dropColumn columnName="uuid" tableName="my_map_list"/>
+    </changeSet>
+    <changeSet id="1752823676768-2" author="student">
+        <addColumn tableName="my_map_list">
+            <column name="uuid" type="VARCHAR(255)">
+                <constraints nullable="false" validateNullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/com/ureca/uhyu/domain/mymap/service/MyMapServiceTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/mymap/service/MyMapServiceTest.java
@@ -1,5 +1,6 @@
 package com.ureca.uhyu.domain.mymap.service;
 
+import com.ureca.uhyu.domain.mymap.dto.request.MyMapReq;
 import com.ureca.uhyu.domain.mymap.dto.response.MyMapRes;
 import com.ureca.uhyu.domain.mymap.entity.MyMapList;
 import com.ureca.uhyu.domain.mymap.enums.MarkerColor;
@@ -21,7 +22,8 @@ import java.lang.reflect.Field;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class MyMapServiceTest {
@@ -80,6 +82,40 @@ class MyMapServiceTest {
         // then
         assertNotNull(result);
         assertTrue(result.isEmpty());
+    }
+
+    @DisplayName("mymap 생성 - 성공")
+    @Test
+    void testCreateMyMapList_success() {
+        // given
+        User user = createUser();
+        setId(user, 1L);
+
+        MyMapReq request = new MyMapReq("나만의 지도", MarkerColor.GREEN, "uuid-1234");
+
+        MyMapList unsaved = MyMapList.builder()
+                .title(request.title())
+                .markerColor(request.markerColor())
+                .uuid(request.uuid())
+                .user(user)
+                .build();
+
+        MyMapList saved = MyMapList.builder()
+                .title(request.title())
+                .markerColor(request.markerColor())
+                .uuid(request.uuid())
+                .user(user)
+                .build();
+        setId(saved, 100L);
+
+        when(myMapListRepository.save(any(MyMapList.class))).thenReturn(saved);
+
+        // when
+        Long result = myMapService.createMyMapList(user, request);
+
+        // then
+        assertEquals(100L, result);
+        verify(myMapListRepository, times(1)).save(any(MyMapList.class));
     }
 
     private User createUser() {


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- Map이름, 마커 색상, uuid 등을 입력 받아 My Map 목록 추가 하는 api 구현
- 프론트와 기능 협의에 따른 엔티티 수정
- 해당 기능 관련 dto 생성
- 기능 검증을 위한 테스트 코드 작성

## ✨ 기타 참고 사항
<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * "My Map" 항목을 생성할 수 있는 기능이 추가되었습니다.

* **버그 수정**
  * 기존 "My Map" 목록 조회 응답의 설명 문구가 소폭 수정되었습니다.

* **데이터베이스**
  * "My Map" 테이블에서 불필요한 컬럼(설명, 공개범위 등)이 제거되고, uuid 컬럼이 문자열 타입으로 변경되었습니다.

* **테스트**
  * "My Map" 생성 기능에 대한 단위 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->