### PR TITLE
[FEAT]/[UHYU-181] my map 삭제 기능 구현 및 my map crud 전반 리팩토링

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/mymap/controller/MyMapController.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/controller/MyMapController.java
@@ -8,6 +8,7 @@ import com.ureca.uhyu.domain.mymap.service.MyMapService;
 import com.ureca.uhyu.domain.user.entity.User;
 import com.ureca.uhyu.global.annotation.CurrentUser;
 import com.ureca.uhyu.global.response.CommonResponse;
+import com.ureca.uhyu.global.response.ResultCode;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -39,5 +40,12 @@ public class MyMapController {
             @CurrentUser User user,
             @RequestBody UpdateMyMapListReq updateMyMapListReq){
         return CommonResponse.success(myMapService.updateMyMapList(user, updateMyMapListReq));
+    }
+
+    @Operation(summary = "My Map List 삭제", description = "지정한 My Map List 삭제")
+    @DeleteMapping("/{mymapId}")
+    public CommonResponse<ResultCode> deleteMyMapList(@CurrentUser User user, @PathVariable Long mymapId) {
+        myMapService.deleteMyMapList(user, mymapId);
+        return CommonResponse.success(ResultCode.MY_MAP_LIST_DELETE_SUCCESS);
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/mymap/controller/MyMapController.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/controller/MyMapController.java
@@ -10,6 +10,7 @@ import com.ureca.uhyu.global.annotation.CurrentUser;
 import com.ureca.uhyu.global.response.CommonResponse;
 import com.ureca.uhyu.global.response.ResultCode;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -30,7 +31,7 @@ public class MyMapController {
 
     @Operation(summary = "My Map List 추가", description = "사용자가 새로운 My Map을 생성")
     @PostMapping
-    public CommonResponse<Long> createMyMapList(@CurrentUser User user, @RequestBody CreateMyMapListReq createMyMapListReq){
+    public CommonResponse<Long> createMyMapList(@CurrentUser User user, @Valid @RequestBody CreateMyMapListReq createMyMapListReq){
         return CommonResponse.success(myMapService.createMyMapList(user, createMyMapListReq));
     }
 

--- a/src/main/java/com/ureca/uhyu/domain/mymap/controller/MyMapController.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/controller/MyMapController.java
@@ -1,6 +1,7 @@
 package com.ureca.uhyu.domain.mymap.controller;
 
 import com.ureca.uhyu.domain.mymap.dto.request.CreateMyMapListReq;
+import com.ureca.uhyu.domain.mymap.dto.response.CreateMyMapListRes;
 import com.ureca.uhyu.domain.mymap.dto.response.MyMapListRes;
 import com.ureca.uhyu.domain.mymap.dto.request.UpdateMyMapListReq;
 import com.ureca.uhyu.domain.mymap.dto.response.UpdateMyMapListRes;
@@ -31,7 +32,7 @@ public class MyMapController {
 
     @Operation(summary = "My Map List 추가", description = "사용자가 새로운 My Map을 생성")
     @PostMapping
-    public CommonResponse<Long> createMyMapList(
+    public CommonResponse<CreateMyMapListRes> createMyMapList(
             @CurrentUser User user,
             @Valid @RequestBody CreateMyMapListReq createMyMapListReq){
         return CommonResponse.success(myMapService.createMyMapList(user, createMyMapListReq));

--- a/src/main/java/com/ureca/uhyu/domain/mymap/controller/MyMapController.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/controller/MyMapController.java
@@ -31,7 +31,9 @@ public class MyMapController {
 
     @Operation(summary = "My Map List 추가", description = "사용자가 새로운 My Map을 생성")
     @PostMapping
-    public CommonResponse<Long> createMyMapList(@CurrentUser User user, @Valid @RequestBody CreateMyMapListReq createMyMapListReq){
+    public CommonResponse<Long> createMyMapList(
+            @CurrentUser User user,
+            @Valid @RequestBody CreateMyMapListReq createMyMapListReq){
         return CommonResponse.success(myMapService.createMyMapList(user, createMyMapListReq));
     }
 
@@ -39,7 +41,7 @@ public class MyMapController {
     @PatchMapping
     public CommonResponse<UpdateMyMapListRes> updateMyMapList(
             @CurrentUser User user,
-            @RequestBody UpdateMyMapListReq updateMyMapListReq){
+            @Valid @RequestBody UpdateMyMapListReq updateMyMapListReq){
         return CommonResponse.success(myMapService.updateMyMapList(user, updateMyMapListReq));
     }
 

--- a/src/main/java/com/ureca/uhyu/domain/mymap/controller/MyMapController.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/controller/MyMapController.java
@@ -47,9 +47,9 @@ public class MyMapController {
     }
 
     @Operation(summary = "My Map List 삭제", description = "지정한 My Map List 삭제")
-    @DeleteMapping("/{mymapId}")
-    public CommonResponse<ResultCode> deleteMyMapList(@CurrentUser User user, @PathVariable Long mymapId) {
-        myMapService.deleteMyMapList(user, mymapId);
+    @DeleteMapping("/{myMapListId}")
+    public CommonResponse<ResultCode> deleteMyMapList(@CurrentUser User user, @PathVariable Long myMapListId) {
+        myMapService.deleteMyMapList(user, myMapListId);
         return CommonResponse.success(ResultCode.MY_MAP_LIST_DELETE_SUCCESS);
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/mymap/dto/request/CreateMyMapListReq.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/dto/request/CreateMyMapListReq.java
@@ -3,11 +3,20 @@ package com.ureca.uhyu.domain.mymap.dto.request;
 import com.ureca.uhyu.domain.mymap.entity.MyMapList;
 import com.ureca.uhyu.domain.mymap.enums.MarkerColor;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 @Schema(description = "My Map 생성 요청 DTO")
 public record CreateMyMapListReq(
+        @NotBlank(message = "제목은 필수입니다")
+        @Size(max = 20, message = "제목은 20자를 초과할 수 없습니다")
         String title,
+
+        @NotNull(message = "마커 색상은 필수입니다")
         MarkerColor markerColor,
+
+        @NotBlank(message = "UUID는 필수입니다")
         String uuid
 ) {
     public static CreateMyMapListReq from(MyMapList myMapList){

--- a/src/main/java/com/ureca/uhyu/domain/mymap/dto/request/UpdateMyMapListReq.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/dto/request/UpdateMyMapListReq.java
@@ -1,9 +1,13 @@
 package com.ureca.uhyu.domain.mymap.dto.request;
 
 import com.ureca.uhyu.domain.mymap.enums.MarkerColor;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record UpdateMyMapListReq(
     Long myMapListId,
+
+    @Size(max = 20, message = "제목은 20자를 초과할 수 없습니다")
     String title,
     MarkerColor markerColor
 ) {

--- a/src/main/java/com/ureca/uhyu/domain/mymap/dto/response/CreateMyMapListRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/dto/response/CreateMyMapListRes.java
@@ -1,0 +1,11 @@
+package com.ureca.uhyu.domain.mymap.dto.response;
+
+import com.ureca.uhyu.domain.mymap.entity.MyMapList;
+
+public record CreateMyMapListRes(
+    Long myMapListId
+) {
+    public static CreateMyMapListRes from(MyMapList myMapList) {
+        return new CreateMyMapListRes(myMapList.getId());
+    }
+}

--- a/src/main/java/com/ureca/uhyu/domain/mymap/dto/response/MyMapListRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/dto/response/MyMapListRes.java
@@ -8,13 +8,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record MyMapListRes(
         Long myMapListId,
         String title,
-        MarkerColor markerColor
+        MarkerColor markerColor,
+        String uuid
 ) {
     public static MyMapListRes from(MyMapList myMapList){
         return new MyMapListRes(
                 myMapList.getId(),
                 myMapList.getTitle(),
-                myMapList.getMarkerColor()
+                myMapList.getMarkerColor(),
+                myMapList.getUuid()
         );
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/mymap/service/MyMapService.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/service/MyMapService.java
@@ -1,6 +1,7 @@
 package com.ureca.uhyu.domain.mymap.service;
 
 import com.ureca.uhyu.domain.mymap.dto.request.CreateMyMapListReq;
+import com.ureca.uhyu.domain.mymap.dto.response.CreateMyMapListRes;
 import com.ureca.uhyu.domain.mymap.dto.response.MyMapListRes;
 import com.ureca.uhyu.domain.mymap.dto.request.UpdateMyMapListReq;
 import com.ureca.uhyu.domain.mymap.dto.response.UpdateMyMapListRes;
@@ -32,7 +33,7 @@ public class MyMapService {
     }
 
     @Transactional
-    public Long createMyMapList(User user,  CreateMyMapListReq createMyMapListReq) {
+    public CreateMyMapListRes createMyMapList(User user, CreateMyMapListReq createMyMapListReq) {
         MyMapList myMapList = MyMapList.builder()
                 .title(createMyMapListReq.title())
                 .markerColor(createMyMapListReq.markerColor())
@@ -41,7 +42,7 @@ public class MyMapService {
                 .build();
         MyMapList savedMyMapList = myMapListRepository.save(myMapList);
 
-        return savedMyMapList.getId();
+        return new CreateMyMapListRes(savedMyMapList.getId());
     }
 
     @Transactional

--- a/src/main/java/com/ureca/uhyu/domain/mymap/service/MyMapService.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/service/MyMapService.java
@@ -63,4 +63,16 @@ public class MyMapService {
         MyMapList savedMyMapList = myMapListRepository.save(myMapList);
         return UpdateMyMapListRes.from(savedMyMapList);
     }
+
+    @Transactional
+    public void deleteMyMapList(User user, Long mymapId) {
+        MyMapList myMapList = myMapListRepository.findById(mymapId)
+                .orElseThrow(() -> new GlobalException(ResultCode.MY_MAP_LIST_NOT_FOUND));
+
+        if (!myMapList.getUser().getId().equals(user.getId())) {
+            throw new GlobalException(ResultCode.FORBIDDEN);
+        }
+
+        myMapListRepository.delete(myMapList);
+    }
 }

--- a/src/main/java/com/ureca/uhyu/domain/mymap/service/MyMapService.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/service/MyMapService.java
@@ -66,8 +66,8 @@ public class MyMapService {
     }
 
     @Transactional
-    public void deleteMyMapList(User user, Long mymapId) {
-        MyMapList myMapList = myMapListRepository.findById(mymapId)
+    public void deleteMyMapList(User user, Long myMapListId) {
+        MyMapList myMapList = myMapListRepository.findById(myMapListId)
                 .orElseThrow(() -> new GlobalException(ResultCode.MY_MAP_LIST_NOT_FOUND));
 
         if (!myMapList.getUser().getId().equals(user.getId())) {

--- a/src/main/java/com/ureca/uhyu/global/response/ResultCode.java
+++ b/src/main/java/com/ureca/uhyu/global/response/ResultCode.java
@@ -43,6 +43,7 @@ public enum ResultCode {
     BOOKMARK_DELETE_SUCCESS(HttpStatus.OK, 4005, "즐겨찾기 삭제가 완료되었습니다."),
     BOOKMARK_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, 4006, "즐겨찾기 리스트가 없습니다."),
     MY_MAP_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, 4007, "My Map 리스트가 없습니다."),
+    MY_MAP_LIST_DELETE_SUCCESS(HttpStatus.OK, 4008, "My Map 리스트 삭제가 완료되었습니다."),
 
     /**
      * 5000번대 (제휴처 관련)

--- a/src/test/java/com/ureca/uhyu/domain/mymap/service/MyMapServiceTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/mymap/service/MyMapServiceTest.java
@@ -1,6 +1,5 @@
 package com.ureca.uhyu.domain.mymap.service;
 
-import com.ureca.uhyu.domain.brand.entity.Brand;
 import com.ureca.uhyu.domain.mymap.dto.request.CreateMyMapListReq;
 import com.ureca.uhyu.domain.mymap.dto.request.UpdateMyMapListReq;
 import com.ureca.uhyu.domain.mymap.dto.response.MyMapListRes;
@@ -8,9 +7,6 @@ import com.ureca.uhyu.domain.mymap.dto.response.UpdateMyMapListRes;
 import com.ureca.uhyu.domain.mymap.entity.MyMapList;
 import com.ureca.uhyu.domain.mymap.enums.MarkerColor;
 import com.ureca.uhyu.domain.mymap.repository.MyMapListRepository;
-import com.ureca.uhyu.domain.store.entity.Store;
-import com.ureca.uhyu.domain.user.entity.Bookmark;
-import com.ureca.uhyu.domain.user.entity.BookmarkList;
 import com.ureca.uhyu.domain.user.entity.Marker;
 import com.ureca.uhyu.domain.user.entity.User;
 import com.ureca.uhyu.domain.user.enums.Gender;

--- a/src/test/java/com/ureca/uhyu/domain/mymap/service/MyMapServiceTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/mymap/service/MyMapServiceTest.java
@@ -47,9 +47,9 @@ class MyMapServiceTest {
         User user = createUser();
         setId(user, 1L);
 
-        MyMapList map1 = createMyMapList(user, "map1", MarkerColor.GREEN);
+        MyMapList map1 = createMyMapList(user, "map1", MarkerColor.GREEN, "uuid1");
         setId(map1, 1L);
-        MyMapList map2 = createMyMapList(user, "map2", MarkerColor.RED);
+        MyMapList map2 = createMyMapList(user, "map2", MarkerColor.RED, "uuid2");
         setId(map2, 2L);
 
         List<MyMapList> myMapLists = List.of(map1, map2);
@@ -66,10 +66,12 @@ class MyMapServiceTest {
         assertEquals(map1.getId(), result.get(0).myMapListId());
         assertEquals(map1.getTitle(), result.get(0).title());
         assertEquals(map1.getMarkerColor(), result.get(0).markerColor());
+        assertEquals(map1.getUuid(), result.get(0).uuid());
 
         assertEquals(map2.getId(), result.get(1).myMapListId());
         assertEquals(map2.getTitle(), result.get(1).title());
         assertEquals(map2.getMarkerColor(), result.get(1).markerColor());
+        assertEquals(map2.getUuid(), result.get(1).uuid());
     }
 
     @DisplayName("mymap 목록 조회 - 빈 리스트 반환")
@@ -131,7 +133,7 @@ class MyMapServiceTest {
         User user = createUser();
         setId(user, 1L);
 
-        MyMapList myMapList = createMyMapList(user, "기존 제목", MarkerColor.GREEN);
+        MyMapList myMapList = createMyMapList(user, "기존 제목", MarkerColor.GREEN, "uuid1");
         setId(myMapList, 100L);
 
         UpdateMyMapListReq req = new UpdateMyMapListReq(
@@ -163,7 +165,7 @@ class MyMapServiceTest {
         User attacker = createUser(); // 공격자
         setId(attacker, 2L);
 
-        MyMapList myMapList = createMyMapList(owner, "원래 제목", MarkerColor.RED);
+        MyMapList myMapList = createMyMapList(owner, "원래 제목", MarkerColor.RED, "uuid1");
         setId(myMapList, 100L);
 
         UpdateMyMapListReq req = new UpdateMyMapListReq(
@@ -189,7 +191,7 @@ class MyMapServiceTest {
         User user = createUser();
         setId(user, 1L);
 
-        MyMapList myMapList = createMyMapList(user, "기존 제목", MarkerColor.GREEN);
+        MyMapList myMapList = createMyMapList(user, "기존 제목", MarkerColor.GREEN, "uuid1");
         setId(myMapList, 100L);
 
         // mock
@@ -212,7 +214,7 @@ class MyMapServiceTest {
         User attacker = createUser();
         setId(attacker, 2L); // 다른 유저
 
-        MyMapList myMapList = createMyMapList(user, "기존 제목", MarkerColor.GREEN);
+        MyMapList myMapList = createMyMapList(user, "기존 제목", MarkerColor.GREEN, "uuid1");
         setId(myMapList, 100L);
 
         // mock
@@ -267,11 +269,12 @@ class MyMapServiceTest {
         return user;
     }
 
-    private MyMapList createMyMapList(User user, String mapName, MarkerColor markerColor) {
+    private MyMapList createMyMapList(User user, String mapName, MarkerColor markerColor, String uuid) {
         return MyMapList.builder()
                 .user(user)
                 .title(mapName)
                 .markerColor(markerColor)
+                .uuid(uuid)
                 .build();
     }
 

--- a/src/test/java/com/ureca/uhyu/domain/mymap/service/MyMapServiceTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/mymap/service/MyMapServiceTest.java
@@ -2,6 +2,7 @@ package com.ureca.uhyu.domain.mymap.service;
 
 import com.ureca.uhyu.domain.mymap.dto.request.CreateMyMapListReq;
 import com.ureca.uhyu.domain.mymap.dto.request.UpdateMyMapListReq;
+import com.ureca.uhyu.domain.mymap.dto.response.CreateMyMapListRes;
 import com.ureca.uhyu.domain.mymap.dto.response.MyMapListRes;
 import com.ureca.uhyu.domain.mymap.dto.response.UpdateMyMapListRes;
 import com.ureca.uhyu.domain.mymap.entity.MyMapList;
@@ -116,10 +117,10 @@ class MyMapServiceTest {
         when(myMapListRepository.save(any(MyMapList.class))).thenReturn(saved);
 
         // when
-        Long result = myMapService.createMyMapList(user, request);
+        CreateMyMapListRes result = myMapService.createMyMapList(user, request);
 
         // then
-        assertEquals(100L, result);
+        assertEquals(100L, result.myMapListId());
         verify(myMapListRepository, times(1)).save(any(MyMapList.class));
     }
 


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- My Map의 id 값을 PathVariable로 전달 받아 해당 My Map을 제거하는 기능 구현
- 해당 기능 관련 dto 작성
- 해당 기능 검증을 위한 단위 테스트 코드 작성
- mymap 생성, 수정 요청 dto에 validation 추가
- dto 수정에 따른 서비스 메서드 코드 일부 수정

## ✨ 기타 참고 사항
<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- my map 수정 브랜치를 merge 받아 구현하였음, 무조건 my map 수정 브랜치를 먼저 develop에 merge할 필요가 있음.

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **신규 기능**
  * 마이 맵 리스트에 대한 생성, 수정, 삭제 기능이 추가되었습니다.
  * 마이 맵 리스트 조회 응답 형식이 개선되었습니다.

* **버그 수정**
  * 마이 맵 리스트 소유자 검증 및 예외 처리가 강화되었습니다.

* **테스트**
  * 마이 맵 리스트의 생성, 수정, 삭제에 대한 단위 테스트가 추가되었습니다.

* **기타**
  * 불필요한 필드(설명, 공개 범위) 제거 및 데이터 구조 일부 변경이 반영되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->