### PR TITLE
[FEAT]/[UHYU-182] UUID 기반 My Map 지도 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,10 @@ dependencies {
 
     // Oauth2
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	// validation
+	implementation("jakarta.validation:jakarta.validation-api")
+	implementation("org.hibernate.validator:hibernate-validator")
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ureca/uhyu/domain/mymap/controller/MyMapController.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/controller/MyMapController.java
@@ -4,6 +4,7 @@ import com.ureca.uhyu.domain.mymap.dto.request.CreateMyMapListReq;
 import com.ureca.uhyu.domain.mymap.dto.response.CreateMyMapListRes;
 import com.ureca.uhyu.domain.mymap.dto.response.MyMapListRes;
 import com.ureca.uhyu.domain.mymap.dto.request.UpdateMyMapListReq;
+import com.ureca.uhyu.domain.mymap.dto.response.MyMapRes;
 import com.ureca.uhyu.domain.mymap.dto.response.UpdateMyMapListRes;
 import com.ureca.uhyu.domain.mymap.service.MyMapService;
 import com.ureca.uhyu.domain.user.entity.User;
@@ -51,5 +52,11 @@ public class MyMapController {
     public CommonResponse<ResultCode> deleteMyMapList(@CurrentUser User user, @PathVariable Long myMapListId) {
         myMapService.deleteMyMapList(user, myMapListId);
         return CommonResponse.success(ResultCode.MY_MAP_LIST_DELETE_SUCCESS);
+    }
+
+    @Operation(summary = "uuid 기반 My Map 지도 조회", description = "my map uuid 기반으로 지도 조회")
+    @GetMapping("/public/{uuid}")
+    public CommonResponse<MyMapRes> getMyMapByUuid(@CurrentUser User user, @PathVariable String uuid) {
+        return CommonResponse.success(myMapService.findMyMap(user, uuid));
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/mymap/controller/MyMapController.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/controller/MyMapController.java
@@ -55,7 +55,7 @@ public class MyMapController {
     }
 
     @Operation(summary = "uuid 기반 My Map 지도 조회", description = "my map uuid 기반으로 지도 조회")
-    @GetMapping("/public/{uuid}")
+    @GetMapping("/{uuid}")
     public CommonResponse<MyMapRes> getMyMapByUuid(@CurrentUser User user, @PathVariable String uuid) {
         return CommonResponse.success(myMapService.findMyMap(user, uuid));
     }

--- a/src/main/java/com/ureca/uhyu/domain/mymap/dto/request/CreateMyMapListReq.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/dto/request/CreateMyMapListReq.java
@@ -5,6 +5,7 @@ import com.ureca.uhyu.domain.mymap.enums.MarkerColor;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 @Schema(description = "My Map 생성 요청 DTO")
@@ -17,6 +18,10 @@ public record CreateMyMapListReq(
         MarkerColor markerColor,
 
         @NotBlank(message = "UUID는 필수입니다")
+        @Pattern(
+                regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                message = "UUID 형식이 올바르지 않습니다"
+        )
         String uuid
 ) {
     public static CreateMyMapListReq from(MyMapList myMapList){

--- a/src/main/java/com/ureca/uhyu/domain/mymap/dto/response/MyMapRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/dto/response/MyMapRes.java
@@ -1,0 +1,37 @@
+package com.ureca.uhyu.domain.mymap.dto.response;
+
+import com.ureca.uhyu.domain.map.dto.response.MapRes;
+import com.ureca.uhyu.domain.mymap.entity.MyMap;
+import com.ureca.uhyu.domain.mymap.entity.MyMapList;
+import com.ureca.uhyu.domain.mymap.enums.MarkerColor;
+import com.ureca.uhyu.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "My Map 조회 응답 DTO")
+public record MyMapRes (
+    MarkerColor markerColor,
+    String title,
+    Long myMapListId,
+    String uuid,
+    List<MapRes> storeList,
+    Boolean isMine
+) {
+    public static MyMapRes from(User user, MyMapList myMapList, List<MyMap> myMapStroes) {
+        List<MapRes> storeList = myMapStroes.stream()
+                .map(myMap -> MapRes.from(myMap.getStore()))
+                .toList();
+
+        boolean isMine = myMapList.getUser().getId().equals(user.getId());
+
+        return new MyMapRes(
+                myMapList.getMarkerColor(),
+                myMapList.getTitle(),
+                myMapList.getId(),
+                myMapList.getUuid(),
+                storeList,
+                isMine
+        );
+    }
+}

--- a/src/main/java/com/ureca/uhyu/domain/mymap/entity/MyMapList.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/entity/MyMapList.java
@@ -23,7 +23,7 @@ public class MyMapList extends BaseEntity {
     @Column(nullable = false)
     private MarkerColor markerColor;
 
-    @Column(name = "uuid", nullable = false)
+    @Column(name = "uuid", nullable = false, unique = true)
     private String uuid;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/ureca/uhyu/domain/mymap/repository/MyMapListRepository.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/repository/MyMapListRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 
 public interface MyMapListRepository extends JpaRepository<MyMapList, Long> {
    List<MyMapList> findByUser(User user);
+
+   MyMapList findByUuid(String uuid);
 }

--- a/src/main/java/com/ureca/uhyu/domain/mymap/repository/MyMapListRepository.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/repository/MyMapListRepository.java
@@ -5,9 +5,10 @@ import com.ureca.uhyu.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MyMapListRepository extends JpaRepository<MyMapList, Long> {
    List<MyMapList> findByUser(User user);
 
-   MyMapList findByUuid(String uuid);
+   Optional<MyMapList> findByUuid(String uuid);
 }

--- a/src/main/java/com/ureca/uhyu/domain/mymap/repository/MyMapRepository.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/repository/MyMapRepository.java
@@ -1,0 +1,11 @@
+package com.ureca.uhyu.domain.mymap.repository;
+
+import com.ureca.uhyu.domain.mymap.entity.MyMap;
+import com.ureca.uhyu.domain.mymap.entity.MyMapList;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MyMapRepository extends JpaRepository<MyMap, Long> {
+    List<MyMap> findByMyMapList(MyMapList myMapList);
+}

--- a/src/main/java/com/ureca/uhyu/domain/mymap/service/MyMapService.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/service/MyMapService.java
@@ -82,7 +82,7 @@ public class MyMapService {
     }
 
     public MyMapRes findMyMap(User user, String uuid) {
-        MyMapList myMapList = myMapListRepository.findByUuid(uuid);
+        MyMapList myMapList = myMapListRepository.findByUuid(uuid).orElseThrow(() -> new GlobalException(ResultCode.MY_MAP_LIST_NOT_FOUND));
         List<MyMap> myMaps = myMapRepository.findByMyMapList(myMapList);
 
         return MyMapRes.from(user, myMapList, myMaps);

--- a/src/main/java/com/ureca/uhyu/domain/mymap/service/MyMapService.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/service/MyMapService.java
@@ -4,10 +4,13 @@ import com.ureca.uhyu.domain.mymap.dto.request.CreateMyMapListReq;
 import com.ureca.uhyu.domain.mymap.dto.response.CreateMyMapListRes;
 import com.ureca.uhyu.domain.mymap.dto.response.MyMapListRes;
 import com.ureca.uhyu.domain.mymap.dto.request.UpdateMyMapListReq;
+import com.ureca.uhyu.domain.mymap.dto.response.MyMapRes;
 import com.ureca.uhyu.domain.mymap.dto.response.UpdateMyMapListRes;
+import com.ureca.uhyu.domain.mymap.entity.MyMap;
 import com.ureca.uhyu.domain.mymap.entity.MyMapList;
 import com.ureca.uhyu.domain.mymap.enums.MarkerColor;
 import com.ureca.uhyu.domain.mymap.repository.MyMapListRepository;
+import com.ureca.uhyu.domain.mymap.repository.MyMapRepository;
 import com.ureca.uhyu.domain.user.entity.User;
 import com.ureca.uhyu.global.exception.GlobalException;
 import com.ureca.uhyu.global.response.ResultCode;
@@ -24,6 +27,7 @@ import java.util.List;
 public class MyMapService {
 
     private final MyMapListRepository myMapListRepository;
+    private final MyMapRepository myMapRepository;
 
     public List<MyMapListRes> findMyMapList(User user) {
         List<MyMapList> myMapLists =  myMapListRepository.findByUser(user);
@@ -75,5 +79,12 @@ public class MyMapService {
         }
 
         myMapListRepository.delete(myMapList);
+    }
+
+    public MyMapRes findMyMap(User user, String uuid) {
+        MyMapList myMapList = myMapListRepository.findByUuid(uuid);
+        List<MyMap> myMaps = myMapRepository.findByMyMapList(myMapList);
+
+        return MyMapRes.from(user, myMapList, myMaps);
     }
 }

--- a/src/main/resources/db/changelog/2025/07/21-01-changelog.xml
+++ b/src/main/resources/db/changelog/2025/07/21-01-changelog.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.29.xsd"
+        objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+    <changeSet id="1753055903524-1" author="student">
+        <addUniqueConstraint columnNames="uuid" constraintName="uc_my_map_list_uuid" tableName="my_map_list"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/com/ureca/uhyu/domain/mymap/service/MyMapServiceTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/mymap/service/MyMapServiceTest.java
@@ -292,7 +292,7 @@ class MyMapServiceTest {
         List<MyMap> myMaps = List.of(myMap1, myMap2);
 
         // mock
-        when(myMapListRepository.findByUuid(uuid)).thenReturn(myMapList);
+        when(myMapListRepository.findByUuid(uuid)).thenReturn(Optional.of(myMapList));
         when(myMapRepository.findByMyMapList(myMapList)).thenReturn(myMaps);
 
         // when


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- UUID를 입력 받으면 UUID에 해당하는 My Map에 속한 매장 리스트를 보여주는 api 구현 
- 해당 My Map의 주인이냐, 혹은 타 사용자이냐에 따라 매장 수정(=My Map에서 삭제)이 가능하도록 구분 짓기위해 응답 dto에 isMine 변수를 추가
- 해당 기능 검증을 위한 단위 테스트 코드 작성

## ✨ 기타 참고 사항
<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 해당 기능 중 매장 목록 및 매장 상세 정보을 받아오기 위해 기존에 매장 상세 조회 기능에서 사용 중인 MapRes dto를 재활용하여 응답 dto를 설계함

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * My Map 리스트 삭제 및 UUID로 My Map 조회 기능이 추가되었습니다.
  * My Map 리스트 생성 시 상세 응답 정보가 제공됩니다.

* **버그 수정**
  * My Map 리스트 생성 및 수정 요청에 대한 입력값 유효성 검사가 강화되었습니다.

* **데이터베이스**
  * My Map 리스트의 UUID에 대한 유니크 제약 조건이 추가되었습니다.

* **테스트**
  * My Map 삭제 및 UUID 기반 조회에 대한 테스트가 추가 및 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->