### PR TITLE
[FEAT][UHYU-100] 추천 조회 api 구현

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationController.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationController.java
@@ -25,7 +25,7 @@ public class RecommendationController {
     @GetMapping("/recommendation")
     public CommonResponse<List<RecommendationResponse>> recommendation(@CurrentUser User user) {
 
-        List<RecommendationResponse> result = recommendationService.getLatedstTop3Recommendations(user);
+        List<RecommendationResponse> result = recommendationService.getLatestTop3Recommendations(user);
 
         return CommonResponse.success(result);
     }

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationController.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationController.java
@@ -1,0 +1,32 @@
+package com.ureca.uhyu.domain.recommendation.controller;
+
+import com.ureca.uhyu.domain.recommendation.dto.RecommendationResponse;
+import com.ureca.uhyu.domain.recommendation.repository.RecommendationRepository;
+import com.ureca.uhyu.domain.recommendation.service.RecommendationService;
+import com.ureca.uhyu.domain.user.entity.User;
+import com.ureca.uhyu.global.annotation.CurrentUser;
+import com.ureca.uhyu.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/users/user")
+@RequiredArgsConstructor
+public class RecommendationController {
+
+    private final RecommendationService recommendationService;
+
+    @Operation(summary = "추천 결과 조회", description = "최근 추천에서 rank 3위까지의 브랜드를 brandName과 함께 반환")
+    @GetMapping("/recommendation")
+    public CommonResponse<List<RecommendationResponse>> recommendation(@CurrentUser User user) {
+
+        List<RecommendationResponse> result = recommendationService.getLatedstTop3Recommendations(user);
+
+        return CommonResponse.success(result);
+    }
+}

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/dto/RecommendationResponse.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/dto/RecommendationResponse.java
@@ -1,0 +1,16 @@
+package com.ureca.uhyu.domain.recommendation.dto;
+
+import com.ureca.uhyu.domain.recommendation.entity.Recommendation;
+import com.ureca.uhyu.domain.recommendation.repository.RecommendationRepository;
+
+public record RecommendationResponse(
+        String brandName,
+        Integer rank
+){
+    public static RecommendationResponse from(Recommendation recommendation) {
+        return new RecommendationResponse(
+                recommendation.getBrandId().getBrandName(),
+                recommendation.getRank()
+        );
+    }
+}

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/dto/RecommendationResponse.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/dto/RecommendationResponse.java
@@ -1,14 +1,15 @@
 package com.ureca.uhyu.domain.recommendation.dto;
 
 import com.ureca.uhyu.domain.recommendation.entity.Recommendation;
-import com.ureca.uhyu.domain.recommendation.repository.RecommendationRepository;
 
 public record RecommendationResponse(
+        Long brandId,
         String brandName,
         Integer rank
 ){
     public static RecommendationResponse from(Recommendation recommendation) {
         return new RecommendationResponse(
+                recommendation.getBrandId().getId(),
                 recommendation.getBrandId().getBrandName(),
                 recommendation.getRank()
         );

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/entity/Recommendation.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/entity/Recommendation.java
@@ -32,15 +32,4 @@ public class Recommendation extends BaseEntity {
 
     @Column(name = "rank")
     private Integer rank;
-
-    @PrePersist
-    protected void onCreate() {
-        this.createdAt = this.updatedAt = LocalDateTime.now();
-    }
-
-    @PreUpdate
-    protected void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
-    }
-
 }

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/entity/Recommendation.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/entity/Recommendation.java
@@ -1,0 +1,46 @@
+package com.ureca.uhyu.domain.recommendation.entity;
+
+import com.ureca.uhyu.domain.brand.entity.Brand;
+import com.ureca.uhyu.domain.brand.entity.Category;
+import com.ureca.uhyu.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "recommendation")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Recommendation extends BaseEntity {
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "brand_id")
+    private Brand brandId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category categoryId;
+
+    @Column(name = "score")
+    private Long score;
+
+    @Column(name = "rank")
+    private Integer rank;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/entity/Recommendation.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/entity/Recommendation.java
@@ -21,11 +21,11 @@ public class Recommendation extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "brand_id")
-    private Brand brandId;
+    private Brand brand;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id")
-    private Category categoryId;
+    private Category category;
 
     @Column(name = "score")
     private Long score;

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/repository/RecommendationRepository.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/repository/RecommendationRepository.java
@@ -1,0 +1,21 @@
+package com.ureca.uhyu.domain.recommendation.repository;
+
+import com.ureca.uhyu.domain.recommendation.entity.Recommendation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface RecommendationRepository extends JpaRepository<Recommendation, Long> {
+
+    List<Recommendation> findByUserId(Long userId);
+
+    // 가장 최신 추천 시간 조회
+    Optional<LocalTime> findTop1CreatedAtByUserIdOrderByCreatedAtDesc(Long userId);
+
+    // 해당 날짜의 추천 중 rank 상위 3개
+    List<Recommendation> findTop3ByUserIdAndCreatedAtOrderByRankAsc(Long userId, LocalTime createdAt);
+}

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/repository/RecommendationRepository.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/repository/RecommendationRepository.java
@@ -4,7 +4,7 @@ import com.ureca.uhyu.domain.recommendation.entity.Recommendation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalTime;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,8 +14,8 @@ public interface RecommendationRepository extends JpaRepository<Recommendation, 
     List<Recommendation> findByUserId(Long userId);
 
     // 가장 최신 추천 시간 조회
-    Optional<LocalTime> findTop1CreatedAtByUserIdOrderByCreatedAtDesc(Long userId);
+    Optional<LocalDateTime> findTop1CreatedAtByUserIdOrderByCreatedAtDesc(Long userId);
 
     // 해당 날짜의 추천 중 rank 상위 3개
-    List<Recommendation> findTop3ByUserIdAndCreatedAtOrderByRankAsc(Long userId, LocalTime createdAt);
+    List<Recommendation> findTop3ByUserIdAndCreatedAtOrderByRankAsc(Long userId, LocalDateTime createdAt);
 }

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/service/RecommendationService.java
@@ -24,16 +24,21 @@ public class RecommendationService {
         // 가장 최근에 추천된 (최신화가 반영된?) 브랜드 가져오기
         LocalTime latestCreatedAt = recommendationRepository
                 .findTop1CreatedAtByUserIdOrderByCreatedAtDesc(userId)
-                .orElseThrow(() -> new GlobalException((ResultCode.NOT_FOUNT_RECOMMENDATION_FOR_USER)));
+                .orElseThrow(() -> new GlobalException((ResultCode.NOT_FOUND_RECOMMENDATION_FOR_USER)));
 
         // 해당 시간의 top3 추천 브랜드 가져오기
         return recommendationRepository.findTop3ByUserIdAndCreatedAtOrderByRankAsc(userId, latestCreatedAt)
                 .stream()
-                .map(r -> new RecommendationResponse(
-                        r.getUserId(),
-                        r.getBrandId().getBrandName(),
-                        r.getRank()
-                ))
+                .map(r -> {
+                    if (r.getBrandId() == null) {
+                        throw new GlobalException((ResultCode.BRAND_ID_IS_NULL));
+                    }
+                    return new RecommendationResponse(
+                            r.getBrandId().getId(),
+                            r.getBrandId().getBrandName(),
+                            r.getRank()
+                    );
+                })
                 .toList();
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/service/RecommendationService.java
@@ -30,6 +30,7 @@ public class RecommendationService {
         return recommendationRepository.findTop3ByUserIdAndCreatedAtOrderByRankAsc(userId, latestCreatedAt)
                 .stream()
                 .map(r -> new RecommendationResponse(
+                        r.getUserId(),
                         r.getBrandId().getBrandName(),
                         r.getRank()
                 ))

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/service/RecommendationService.java
@@ -18,7 +18,7 @@ public class RecommendationService {
 
     private final RecommendationRepository recommendationRepository;
 
-    public List<RecommendationResponse> getLatedstTop3Recommendations(User user) {
+    public List<RecommendationResponse> getLatestTop3Recommendations(User user) {
         Long userId = user.getId();
 
         // 가장 최근에 추천된 (최신화가 반영된?) 브랜드 가져오기

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/service/RecommendationService.java
@@ -1,0 +1,38 @@
+package com.ureca.uhyu.domain.recommendation.service;
+
+import com.ureca.uhyu.domain.recommendation.dto.RecommendationResponse;
+import com.ureca.uhyu.domain.recommendation.repository.RecommendationRepository;
+import com.ureca.uhyu.domain.user.entity.User;
+import com.ureca.uhyu.global.exception.GlobalException;
+import com.ureca.uhyu.global.response.ResultCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RecommendationService {
+
+    private final RecommendationRepository recommendationRepository;
+
+    public List<RecommendationResponse> getLatedstTop3Recommendations(User user) {
+        Long userId = user.getId();
+
+        // 가장 최근에 추천된 (최신화가 반영된?) 브랜드 가져오기
+        LocalTime latestCreatedAt = recommendationRepository
+                .findTop1CreatedAtByUserIdOrderByCreatedAtDesc(userId)
+                .orElseThrow(() -> new GlobalException((ResultCode.NOT_FOUNT_RECOMMENDATION_FOR_USER)));
+
+        // 해당 시간의 top3 추천 브랜드 가져오기
+        return recommendationRepository.findTop3ByUserIdAndCreatedAtOrderByRankAsc(userId, latestCreatedAt)
+                .stream()
+                .map(r -> new RecommendationResponse(
+                        r.getBrandId().getBrandName(),
+                        r.getRank()
+                ))
+                .toList();
+    }
+}

--- a/src/main/java/com/ureca/uhyu/domain/user/entity/ActionLogs.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/entity/ActionLogs.java
@@ -21,6 +21,9 @@ public class ActionLogs extends BaseEntity {
     @Column(name = "store_id", nullable = true)
     Long storeId;
 
+    @Column(name = "category_id", nullable = true)
+    Long categoryId;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;

--- a/src/main/java/com/ureca/uhyu/global/response/ResultCode.java
+++ b/src/main/java/com/ureca/uhyu/global/response/ResultCode.java
@@ -43,8 +43,8 @@ public enum ResultCode {
     BOOKMARK_DELETE_SUCCESS(HttpStatus.OK, 4005, "즐겨찾기 삭제가 완료되었습니다."),
     BOOKMARK_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, 4006, "즐겨찾기 리스트가 없습니다."),
     MY_MAP_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, 4007, "My Map 리스트가 없습니다."),
-    NOT_FOUNT_RECOMMENDATION_FOR_USER(HttpStatus.NOT_FOUND, 4008, "추천 결과가 존재하지 않습니다"),
-    BRAND_ID_IS_NULL(HttpStatus.NOT_FOUND, 4009, "brand id가 존재하지 않습니다.");
+    NOT_FOUND_RECOMMENDATION_FOR_USER(HttpStatus.NOT_FOUND, 4008, "추천 결과가 존재하지 않습니다"),
+    BRAND_ID_IS_NULL(HttpStatus.NOT_FOUND, 4009, "brand id가 존재하지 않습니다."),
 
 
     /**

--- a/src/main/java/com/ureca/uhyu/global/response/ResultCode.java
+++ b/src/main/java/com/ureca/uhyu/global/response/ResultCode.java
@@ -41,7 +41,8 @@ public enum ResultCode {
     EMAIL_DUPLICATED(HttpStatus.BAD_REQUEST, 4003, "이미 사용중인 이메일입니다."),
     BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, 4004, "즐겨찾기 정보를 찾을 수 없습니다."),
     BOOKMARK_DELETE_SUCCESS(HttpStatus.OK, 4005, "즐겨찾기 삭제가 완료되었습니다."),
-    BOOKMARK_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, 4006, "즐겨찾기 리스트가 없습니다.");
+    BOOKMARK_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, 4006, "즐겨찾기 리스트가 없습니다."),
+    NOT_FOUNT_RECOMMENDATION_FOR_USER(HttpStatus.NOT_FOUND, 4007, "추천 결과가 존재하지 않습니다");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/ureca/uhyu/global/response/ResultCode.java
+++ b/src/main/java/com/ureca/uhyu/global/response/ResultCode.java
@@ -42,7 +42,8 @@ public enum ResultCode {
     BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, 4004, "즐겨찾기 정보를 찾을 수 없습니다."),
     BOOKMARK_DELETE_SUCCESS(HttpStatus.OK, 4005, "즐겨찾기 삭제가 완료되었습니다."),
     BOOKMARK_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, 4006, "즐겨찾기 리스트가 없습니다."),
-    NOT_FOUNT_RECOMMENDATION_FOR_USER(HttpStatus.NOT_FOUND, 4007, "추천 결과가 존재하지 않습니다");
+    NOT_FOUND_RECOMMENDATION_FOR_USER(HttpStatus.NOT_FOUND, 4008, "추천 결과가 존재하지 않습니다"),
+    BRAND_ID_IS_NULL(HttpStatus.NOT_FOUND, 4009, "brand id가 존재하지 않습니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/test/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationControllerTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationControllerTest.java
@@ -73,7 +73,6 @@ class RecommendationControllerTest {
                 .andDo(print());
 
         // then
-        // then
         result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.data[0].brandName").value("스타벅스"))
                 .andExpect(jsonPath("$.data[0].rank").value(1))

--- a/src/test/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationControllerTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationControllerTest.java
@@ -58,9 +58,7 @@ class RecommendationControllerTest {
         List<RecommendationResponse> mockResponse = List.of(
                 new RecommendationResponse(1L, "스타벅스", 1),
                 new RecommendationResponse(2L, "이디야", 2),
-                new RecommendationResponse(3L, "투썸플레이스", 3),
-                new RecommendationResponse(4L, "굽네치킨", 4),
-                new RecommendationResponse(5L, "롯데월드", 5)
+                new RecommendationResponse(3L, "투썸플레이스", 3)
         );
 
         given(recommendationService.getLatestTop3Recommendations(any(User.class)))

--- a/src/test/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationControllerTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationControllerTest.java
@@ -56,11 +56,11 @@ class RecommendationControllerTest {
     void it_returns_top3_recommendations() throws Exception {
         // given
         List<RecommendationResponse> mockResponse = List.of(
-                new RecommendationResponse("스타벅스", 1),
-                new RecommendationResponse("이디야", 2),
-                new RecommendationResponse("투썸플레이스", 3),
-                new RecommendationResponse("굽네치킨", 4),
-                new RecommendationResponse("롯데월드", 5)
+                new RecommendationResponse(1L, "스타벅스", 1),
+                new RecommendationResponse(2L, "이디야", 2),
+                new RecommendationResponse(3L, "투썸플레이스", 3),
+                new RecommendationResponse(4L, "굽네치킨", 4),
+                new RecommendationResponse(5L, "롯데월드", 5)
         );
 
         given(recommendationService.getLatestTop3Recommendations(any(User.class)))

--- a/src/test/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationControllerTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationControllerTest.java
@@ -1,0 +1,83 @@
+package com.ureca.uhyu.domain.recommendation.controller;
+
+import com.ureca.uhyu.domain.recommendation.dto.RecommendationResponse;
+import com.ureca.uhyu.domain.recommendation.service.RecommendationService;
+import com.ureca.uhyu.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@ExtendWith(MockitoExtension.class)
+class RecommendationControllerTest {
+
+    private static final String RECOMMEND_URL = "/users/user/recommendation";
+
+    private MockMvc mockMvc;
+
+    @InjectMocks
+    private RecommendationController recommendationController;
+
+    @Mock
+    private RecommendationService recommendationService;
+
+    @BeforeEach
+    void setup() {
+        mockMvc = MockMvcBuilders.standaloneSetup(recommendationController)
+                .addFilters(new CharacterEncodingFilter("UTF-8", true))
+                .build();
+
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken("userId", null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @Test
+    @DisplayName("가장 최신 추천 결과 Top3 브랜드를 반환한다")
+    void it_returns_top3_recommendations() throws Exception {
+        // given
+        List<RecommendationResponse> mockResponse = List.of(
+                new RecommendationResponse("스타벅스", 1),
+                new RecommendationResponse("이디야", 2),
+                new RecommendationResponse("투썸플레이스", 3),
+                new RecommendationResponse("굽네치킨", 4),
+                new RecommendationResponse("롯데월드", 5)
+        );
+
+        given(recommendationService.getLatestTop3Recommendations(any(User.class)))
+                .willReturn(mockResponse);
+
+        // when
+        ResultActions result = mockMvc.perform(get(RECOMMEND_URL)
+                        .header("Authorization", "Bearer mock-token")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].brandName").value("스타벅스"))
+                .andExpect(jsonPath("$.data[0].rank").value(1))
+                .andExpect(jsonPath("$.data[1].brandName").value("이디야"))
+                .andExpect(jsonPath("$.data[2].brandName").value("투썸플레이스"));
+    }
+}


### PR DESCRIPTION
## 📌 작업 개요
- 사용자 맞춤 추천 브랜드가 저장된 DB 조회 api 구현
- brand_id, brand_name, rank(최대 3) response
- 사용자별 추천 정보 중 가장 최근에 추천되었던 정보 반영

## ✨ 기타 참고 사항
- 아직 비로그인 사용자에게 어떤 추천값을 반환할지는 구현되지 않았습니다.

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **신규 기능**
  * 사용자의 상위 3개 추천 브랜드를 조회할 수 있는 추천 API가 추가되었습니다.

* **버그 수정**
  * ActionLogs 엔티티에 categoryId 필드가 추가되어 카테고리 정보가 저장됩니다.

* **테스트**
  * 추천 API의 동작을 검증하는 테스트가 추가되었습니다.

* **기타**
  * 추천 결과가 없을 때와 브랜드 ID가 없을 때의 에러 코드가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->