### PR TITLE
[FEAT][UHYU-198] My Map 매장 등록 유무 조회 및 일부 코드 리팩토링(온보딩, uuid 기반 mymap 지도 조회)

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/mymap/controller/MyMapController.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/controller/MyMapController.java
@@ -1,11 +1,8 @@
 package com.ureca.uhyu.domain.mymap.controller;
 
 import com.ureca.uhyu.domain.mymap.dto.request.CreateMyMapListReq;
-import com.ureca.uhyu.domain.mymap.dto.response.CreateMyMapListRes;
-import com.ureca.uhyu.domain.mymap.dto.response.MyMapListRes;
+import com.ureca.uhyu.domain.mymap.dto.response.*;
 import com.ureca.uhyu.domain.mymap.dto.request.UpdateMyMapListReq;
-import com.ureca.uhyu.domain.mymap.dto.response.MyMapRes;
-import com.ureca.uhyu.domain.mymap.dto.response.UpdateMyMapListRes;
 import com.ureca.uhyu.domain.mymap.service.MyMapService;
 import com.ureca.uhyu.domain.user.entity.User;
 import com.ureca.uhyu.global.annotation.CurrentUser;
@@ -58,5 +55,11 @@ public class MyMapController {
     @GetMapping("/{uuid}")
     public CommonResponse<MyMapRes> getMyMapByUuid(@CurrentUser User user, @PathVariable String uuid) {
         return CommonResponse.success(myMapService.findMyMap(user, uuid));
+    }
+
+    @Operation(summary = "My Map 매장 등록 유무 조회", description = "My Map에 매장 추가 시 해당 My Map에 등록 유무를 조회")
+    @GetMapping("/list/{store_id}")
+    public CommonResponse<BookmarkedMyMapRes> getMyMapListWithIsBookmarked(@CurrentUser User user, @PathVariable(name = "store_id") Long storeId) {
+        return CommonResponse.success(myMapService.findMyMapListWithIsBookmarked(user, storeId));
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/mymap/dto/response/BookmarkedMyMapListRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/dto/response/BookmarkedMyMapListRes.java
@@ -1,0 +1,21 @@
+package com.ureca.uhyu.domain.mymap.dto.response;
+
+
+import com.ureca.uhyu.domain.mymap.entity.MyMapList;
+import com.ureca.uhyu.domain.mymap.enums.MarkerColor;
+
+public record BookmarkedMyMapListRes(
+        Long MyMapListId,
+        MarkerColor markerColor,
+        String title,
+        Boolean isMyMapped
+) {
+    public static  BookmarkedMyMapListRes from(MyMapList myMapList, boolean isMyMapped){
+        return new BookmarkedMyMapListRes(
+                myMapList.getId(),
+                myMapList.getMarkerColor(),
+                myMapList.getTitle(),
+                isMyMapped
+        );
+    }
+}

--- a/src/main/java/com/ureca/uhyu/domain/mymap/dto/response/BookmarkedMyMapListRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/dto/response/BookmarkedMyMapListRes.java
@@ -5,7 +5,7 @@ import com.ureca.uhyu.domain.mymap.entity.MyMapList;
 import com.ureca.uhyu.domain.mymap.enums.MarkerColor;
 
 public record BookmarkedMyMapListRes(
-        Long MyMapListId,
+        Long myMapListId,
         MarkerColor markerColor,
         String title,
         Boolean isMyMapped

--- a/src/main/java/com/ureca/uhyu/domain/mymap/dto/response/BookmarkedMyMapRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/dto/response/BookmarkedMyMapRes.java
@@ -1,0 +1,21 @@
+package com.ureca.uhyu.domain.mymap.dto.response;
+
+import com.ureca.uhyu.domain.store.entity.Store;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "My Map 매장 등록 유무 조회 응답 DTO")
+public record BookmarkedMyMapRes (
+        String storeName,
+        List<BookmarkedMyMapListRes> bookmarkedMyMapLists,
+        Boolean isBookmarked
+){
+    public static BookmarkedMyMapRes from(Store store, List<BookmarkedMyMapListRes> bookmarkedMyMapLists, boolean isBookmarked){
+        return new BookmarkedMyMapRes(
+                store.getName(),
+                bookmarkedMyMapLists,
+                isBookmarked
+        );
+    }
+}

--- a/src/main/java/com/ureca/uhyu/domain/mymap/dto/response/MyMapRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/dto/response/MyMapRes.java
@@ -18,13 +18,7 @@ public record MyMapRes (
     List<MapRes> storeList,
     Boolean isMine
 ) {
-    public static MyMapRes from(User user, MyMapList myMapList, List<MyMap> myMapStroes) {
-        List<MapRes> storeList = myMapStroes.stream()
-                .map(myMap -> MapRes.from(myMap.getStore()))
-                .toList();
-
-        boolean isMine = myMapList.getUser().getId().equals(user.getId());
-
+    public static MyMapRes from(MyMapList myMapList, List<MapRes> storeList, boolean isMine) {
         return new MyMapRes(
                 myMapList.getMarkerColor(),
                 myMapList.getTitle(),

--- a/src/main/java/com/ureca/uhyu/domain/mymap/repository/MyMapRepository.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/repository/MyMapRepository.java
@@ -4,8 +4,11 @@ import com.ureca.uhyu.domain.mymap.entity.MyMap;
 import com.ureca.uhyu.domain.mymap.entity.MyMapList;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface MyMapRepository extends JpaRepository<MyMap, Long> {
     List<MyMap> findByMyMapList(MyMapList myMapList);
+
+    List<MyMap> findByMyMapListIn(Collection<MyMapList> myMapLists);
 }

--- a/src/main/java/com/ureca/uhyu/domain/mymap/service/MyMapService.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/service/MyMapService.java
@@ -23,7 +23,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -108,9 +111,16 @@ public class MyMapService {
         //MyMap 안에 store가 있는지 검증
         List<MyMapList> myMapLists = myMapListRepository.findByUser(user);
 
+        // 모든 MyMapList에 대한 MyMap을 한 번에 조회
+        List<MyMap> allMyMaps = myMapRepository.findByMyMapListIn(myMapLists);
+
+        // MyMapList별로 그룹화
+        Map<Long, List<MyMap>> myMapsByListId = allMyMaps.stream()
+                .collect(Collectors.groupingBy(myMap -> myMap.getMyMapList().getId()));
+
         List<BookmarkedMyMapListRes> myMapListResponses = myMapLists.stream()
                 .map(myMapList -> {
-                    List<MyMap> myMaps = myMapRepository.findByMyMapList(myMapList); // ← 핵심 수정 부분
+                    List<MyMap> myMaps = myMapsByListId.getOrDefault(myMapList.getId(), Collections.emptyList());
                     boolean isMapped = myMaps.stream()
                             .anyMatch(myMap -> myMap.getStore().getId().equals(storeId));
                     return BookmarkedMyMapListRes.from(myMapList, isMapped);

--- a/src/main/java/com/ureca/uhyu/domain/user/entity/BookmarkList.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/entity/BookmarkList.java
@@ -11,7 +11,7 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class BookmarkList extends BaseEntity {
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 }

--- a/src/main/java/com/ureca/uhyu/domain/user/repository/BookmarkListRepository.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/repository/BookmarkListRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 
 public interface BookmarkListRepository extends JpaRepository<BookmarkList, Long> {
     Optional<BookmarkList> findByUser(User user);
+
+    boolean existsByUser(User user);
 }

--- a/src/main/java/com/ureca/uhyu/domain/user/service/UserService.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/service/UserService.java
@@ -46,6 +46,12 @@ public class UserService {
         saveUserBrandData(user, request.recentBrands(), DataType.RECENT);
         saveUserBrandData(user, request.interestedBrands(), DataType.INTEREST);
 
+        //온보딩 시 해당 user에 대한 즐겨찾기 List도 생성
+        BookmarkList bookmarkList = BookmarkList.builder()
+                .user(user)
+                .build();
+        bookmarkListRepository.save(bookmarkList);
+
         return user.getId();
     }
 

--- a/src/main/java/com/ureca/uhyu/domain/user/service/UserService.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/service/UserService.java
@@ -47,10 +47,15 @@ public class UserService {
         saveUserBrandData(user, request.interestedBrands(), DataType.INTEREST);
 
         //온보딩 시 해당 user에 대한 즐겨찾기 List도 생성
-        BookmarkList bookmarkList = BookmarkList.builder()
-                .user(user)
-                .build();
-        bookmarkListRepository.save(bookmarkList);
+        if (bookmarkListRepository.existsByUser(user)) {
+            throw new GlobalException(ResultCode.BOOKMARK_LIST_ALREADY_EXISTS);
+        }
+        else {
+            BookmarkList bookmarkList = BookmarkList.builder()
+                    .user(user)
+                    .build();
+            bookmarkListRepository.save(bookmarkList);
+        }
 
         return user.getId();
     }

--- a/src/main/java/com/ureca/uhyu/global/response/ResultCode.java
+++ b/src/main/java/com/ureca/uhyu/global/response/ResultCode.java
@@ -42,10 +42,11 @@ public enum ResultCode {
     BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, 4004, "즐겨찾기 정보를 찾을 수 없습니다."),
     BOOKMARK_DELETE_SUCCESS(HttpStatus.OK, 4005, "즐겨찾기 삭제가 완료되었습니다."),
     BOOKMARK_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, 4006, "즐겨찾기 리스트가 없습니다."),
-    MY_MAP_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, 4007, "My Map 리스트가 없습니다."),
-    MY_MAP_LIST_DELETE_SUCCESS(HttpStatus.OK, 4008, "My Map 리스트 삭제가 완료되었습니다."),
-    NOT_FOUND_RECOMMENDATION_FOR_USER(HttpStatus.NOT_FOUND, 4009, "추천 결과가 존재하지 않습니다"),
-    BRAND_ID_IS_NULL(HttpStatus.NOT_FOUND, 4010, "brand id가 존재하지 않습니다."),
+    BOOKMARK_LIST_ALREADY_EXISTS(HttpStatus.CONFLICT, 4007, "즐겨찾기 리스트가 이미 존재합니다."),
+    MY_MAP_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, 4008, "My Map 리스트가 없습니다."),
+    MY_MAP_LIST_DELETE_SUCCESS(HttpStatus.OK, 4009, "My Map 리스트 삭제가 완료되었습니다."),
+    NOT_FOUND_RECOMMENDATION_FOR_USER(HttpStatus.NOT_FOUND, 4010, "추천 결과가 존재하지 않습니다"),
+    BRAND_ID_IS_NULL(HttpStatus.NOT_FOUND, 4011, "brand id가 존재하지 않습니다."),
 
 
     /**

--- a/src/main/resources/db/changelog/2025/07/21-02-changelog.xml
+++ b/src/main/resources/db/changelog/2025/07/21-02-changelog.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.29.xsd"  objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+  <changeSet id="1753083017494-1" author="student">
+<createTable tableName="recommendation">
+            <column autoIncrement="true" name="id" type="BIGINT">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_recommendation"/>
+            </column>
+            <column name="created_at" type="DATETIME"/>
+            <column name="updated_at" type="DATETIME"/>
+            <column name="user_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="brand_id" type="BIGINT"/>
+            <column name="category_id" type="BIGINT"/>
+            <column name="score" type="BIGINT"/>
+            <column name="rank" type="INT"/>
+        </createTable>
+</changeSet>
+<changeSet id="1753083017494-2" author="student">
+<addColumn tableName="action_logs">
+            <column name="category_id" type="BIGINT"/></addColumn>
+</changeSet>
+<changeSet id="1753083017494-3" author="student">
+<addUniqueConstraint columnNames="user_id" constraintName="uc_bookmark_list_user" tableName="bookmark_list"/>
+</changeSet>
+<changeSet id="1753083017494-4" author="student">
+<addForeignKeyConstraint baseColumnNames="brand_id" baseTableName="recommendation" constraintName="FK_RECOMMENDATION_ON_BRAND" referencedColumnNames="id" referencedTableName="brands"/>
+</changeSet>
+<changeSet id="1753083017494-5" author="student">
+<addForeignKeyConstraint baseColumnNames="category_id" baseTableName="recommendation" constraintName="FK_RECOMMENDATION_ON_CATEGORY" referencedColumnNames="id" referencedTableName="categories"/>
+</changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/com/ureca/uhyu/domain/mymap/service/MyMapServiceTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/mymap/service/MyMapServiceTest.java
@@ -422,9 +422,11 @@ class MyMapServiceTest {
         MyMapList list2 = createMyMapList(user, "마이맵 2", MarkerColor.YELLOW, "uuid-2");
         setId(list1, 200L);
         setId(list2, 201L);
+        List<MyMapList> lists = List.of(list1, list2);
 
         MyMap map1 = createMyMap(list1, store); // list1에 포함
         MyMap map2 = createMyMap(list2, store2); // list2에는 포함 안 됨
+        List<MyMap> myMaps = List.of(map1, map2);
 
         BookmarkList bookmarkList = BookmarkList.builder().user(user).build();
         setId(bookmarkList, 300L);
@@ -435,8 +437,7 @@ class MyMapServiceTest {
         // mock
         when(storeRepository.findById(100L)).thenReturn(Optional.of(store));
         when(myMapListRepository.findByUser(user)).thenReturn(List.of(list1, list2));
-        when(myMapRepository.findByMyMapList(list1)).thenReturn(List.of(map1));
-        when(myMapRepository.findByMyMapList(list2)).thenReturn(List.of(map2));
+        when(myMapRepository.findByMyMapListIn(lists)).thenReturn(List.of(map1, map2));
         when(bookmarkListRepository.findByUser(user)).thenReturn(Optional.of(bookmarkList));
         when(bookmarkRepository.findByBookmarkList(bookmarkList)).thenReturn(List.of(bookmark));
 
@@ -450,20 +451,20 @@ class MyMapServiceTest {
         assertEquals(2, result.bookmarkedMyMapLists().size());
 
         BookmarkedMyMapListRes res1 = result.bookmarkedMyMapLists().get(0);
-        assertEquals(200L, res1.MyMapListId());
+        assertEquals(200L, res1.myMapListId());
         assertEquals("마이맵 1", res1.title());
         assertEquals(MarkerColor.GREEN, res1.markerColor());
         assertTrue(res1.isMyMapped());
 
         BookmarkedMyMapListRes res2 = result.bookmarkedMyMapLists().get(1);
-        assertEquals(201L, res2.MyMapListId());
+        assertEquals(201L, res2.myMapListId());
         assertEquals("마이맵 2", res2.title());
         assertEquals(MarkerColor.YELLOW, res2.markerColor());
         assertFalse(res2.isMyMapped());
 
         verify(storeRepository).findById(100L);
         verify(myMapListRepository).findByUser(user);
-        verify(myMapRepository, times(2)).findByMyMapList(any());
+        verify(myMapRepository, times(1)).findByMyMapListIn(any());
         verify(bookmarkListRepository).findByUser(user);
         verify(bookmarkRepository).findByBookmarkList(bookmarkList);
     }

--- a/src/test/java/com/ureca/uhyu/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/user/service/UserServiceTest.java
@@ -347,7 +347,7 @@ class UserServiceTest {
         // mock
         when(historyRepository.findDiscountMoneyThisMonth(user)).thenReturn(discountMoney);
         when(actionLogsRepository.findTop3ClickedBrands(user)).thenReturn(topBrands);
-        when(historyRepository.findTop3RecentStore(user)).thenReturn(recentStores);
+        when(historyRepository.findRecentStoreInMonth(user)).thenReturn(recentStores);
 
         // when
         UserStatisticsRes result = userService.findUserStatistics(user);


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- My Map 매장 등록 유무 조회 기능 구현
- 관련 dto 생성
- uuid 기반 mymap 지도 조회 응답 dto 및 서비스 로직 리팩토링
- 신규 사용자 온보딩 시 해당 사용자의 BookmarkList도 생성되도록 기능 추가
- 해당 기능 검증을 위한 단위 테스트 코드 작성 (성공, 실패 케이스)
- db 형상관리를 위한 changelog 추가

## ✨ 기타 참고 사항
<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 온보딩 부분에서 BookmarkList 생성부분 확인해주셨으면 합니다!

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 특정 매장이 사용자의 마이맵에 등록되어 있는지와 북마크에 포함되어 있는지 함께 확인할 수 있는 조회 API가 추가되었습니다.
  * 사용자의 마이맵 리스트별로 매장 등록 여부를 상세히 확인할 수 있습니다.

* **버그 수정**
  * 북마크 리스트와 사용자 간의 관계가 1:1로 변경되어 데이터 일관성과 무결성이 향상되었습니다.

* **데이터베이스**
  * 추천 정보를 위한 recommendation 테이블이 추가되었습니다.
  * action_logs 테이블에 category_id 컬럼이 추가되었습니다.
  * bookmark_list 테이블에 user_id의 유니크 제약조건이 추가되었습니다.

* **테스트**
  * 마이맵 및 북마크 관련 신규 기능에 대한 단위 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->