### PR TITLE
[FEAT][UHYU-78] 카테고리 목록 조회 api 기능 구현

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/brand/controller/CategoryController.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/controller/CategoryController.java
@@ -1,0 +1,26 @@
+package com.ureca.uhyu.domain.brand.controller;
+
+import com.ureca.uhyu.domain.brand.dto.response.CategoryListRes;
+import com.ureca.uhyu.domain.brand.entity.Category;
+import com.ureca.uhyu.domain.brand.repository.CategoryRepository;
+import com.ureca.uhyu.domain.brand.service.CategoryService;
+import com.ureca.uhyu.global.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/categories")
+@RequiredArgsConstructor
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @GetMapping
+    public CommonResponse<List<CategoryListRes>> getCategories() {
+        return CommonResponse.success(categoryService.getAllCategories());
+    }
+}

--- a/src/main/java/com/ureca/uhyu/domain/brand/controller/CategoryController.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/controller/CategoryController.java
@@ -1,8 +1,6 @@
 package com.ureca.uhyu.domain.brand.controller;
 
 import com.ureca.uhyu.domain.brand.dto.response.CategoryListRes;
-import com.ureca.uhyu.domain.brand.entity.Category;
-import com.ureca.uhyu.domain.brand.repository.CategoryRepository;
 import com.ureca.uhyu.domain.brand.service.CategoryService;
 import com.ureca.uhyu.global.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/categories")
+@RequestMapping("/admin/categories")
 @RequiredArgsConstructor
 public class CategoryController {
 

--- a/src/main/java/com/ureca/uhyu/domain/brand/dto/response/CategoryListRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/dto/response/CategoryListRes.java
@@ -1,0 +1,12 @@
+package com.ureca.uhyu.domain.brand.dto.response;
+
+import com.ureca.uhyu.domain.brand.entity.Category;
+
+public record CategoryListRes (
+        Long categoryId,
+        String categoryName
+){
+    public static CategoryListRes from(Category category) {
+        return new CategoryListRes(category.getId(), category.getCategoryName());
+    }
+}

--- a/src/main/java/com/ureca/uhyu/domain/brand/service/CategoryService.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/service/CategoryService.java
@@ -1,0 +1,31 @@
+package com.ureca.uhyu.domain.brand.service;
+
+import com.ureca.uhyu.domain.brand.dto.response.CategoryListRes;
+import com.ureca.uhyu.domain.brand.repository.CategoryRepository;
+import com.ureca.uhyu.global.exception.GlobalException;
+import com.ureca.uhyu.global.response.ResultCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    @Transactional
+    public List<CategoryListRes> getAllCategories() {
+        try {
+            return categoryRepository.findAll().stream()
+                    .map(CategoryListRes::from)
+                    .toList();
+        } catch (Exception e) {
+            throw new GlobalException(ResultCode.CATEGORY_NOT_FOUND);
+        }
+    }
+}

--- a/src/test/java/com/ureca/uhyu/domain/brand/controller/CategoryControllerTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/brand/controller/CategoryControllerTest.java
@@ -1,0 +1,90 @@
+package com.ureca.uhyu.domain.brand.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ureca.uhyu.domain.brand.dto.response.CategoryListRes;
+import com.ureca.uhyu.domain.brand.repository.CategoryRepository;
+import com.ureca.uhyu.domain.brand.service.CategoryService;
+import com.ureca.uhyu.global.config.TestSecurityConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(CategoryController.class)
+@Import(TestSecurityConfig.class)
+class CategoryControllerTest {
+
+    private static final String CATEGORY_URL = "/admin/categories";
+
+//    @WebMvcTest(controllers = CategoryController.class, excludeAutoConfiguration = SecurityAutoConfiguration.class)
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CategoryService categoryService;
+
+    @BeforeEach
+    void initSecurity() {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        "mockUser", null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN"))
+                )
+        );
+    }
+
+    @Nested
+    @DisplayName("카테고리 목록 조회 요청은")
+    class Describe_getCategories {
+
+        @Test
+        @DisplayName("정상적인 경우 200과 카테고리 리스트를 반환한다")
+        void it_returns_category_list() throws Exception {
+            // given
+            List<CategoryListRes> mockCategories = List.of(
+                    new CategoryListRes(1L, "테마파크"),
+                    new CategoryListRes(2L, "쇼핑")
+            );
+
+            when(categoryService.getAllCategories()).thenReturn(mockCategories);
+
+            // when
+            ResultActions result = mockMvc.perform(get(CATEGORY_URL)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print());
+
+            // then
+            result.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data[0].categoryId").value(1))
+                    .andExpect(jsonPath("$.data[0].categoryName").value("테마파크"))
+                    .andExpect(jsonPath("$.data[1].categoryId").value(2))
+                    .andExpect(jsonPath("$.data[1].categoryName").value("쇼핑"));
+
+            verify(categoryService, times(1)).getAllCategories();
+        }
+    }
+}

--- a/src/test/java/com/ureca/uhyu/global/config/TestSecurityConfig.java
+++ b/src/test/java/com/ureca/uhyu/global/config/TestSecurityConfig.java
@@ -1,0 +1,31 @@
+package com.ureca.uhyu.global.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+public class TestSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .csrf(Customizer.withDefaults())
+                .logout(Customizer.withDefaults());
+
+        return http.build();
+    }
+
+    /**
+     * @Bean
+     * public SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
+     *     return http
+     *         .securityMatcher("/**")
+     *         .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+     *         .build();
+     * }
+     */
+}


### PR DESCRIPTION
## 📌 작업 개요
- 어드민에서 브랜드를 추가할 때 DB에 저장된 카테고리 목록 조회 api 개발

## ✨ 기타 참고 사항
- 

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 관리자를 위한 카테고리 목록 조회 API가 추가되었습니다. 이제 `/admin/categories` 경로에서 모든 카테고리 정보를 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->