### PR TITLE
[FEAT][UHYU-211] 온보딩 관심 및 방문 브랜드 저장 String -> Long 변경

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/user/dto/request/UserOnboardingRequest.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/dto/request/UserOnboardingRequest.java
@@ -25,7 +25,7 @@ public record UserOnboardingRequest(
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
         @NotEmpty(message = "최근 이용 브랜드는 1개 이상 입력해야 합니다.")
-        List<String> recentBrands,
+        List<Long> recentBrands,
 
         @Schema(
                 description = "관심 있는 브랜드 목록 (최소 1개 이상)",
@@ -33,6 +33,6 @@ public record UserOnboardingRequest(
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
         @NotEmpty(message = "관심 있는 브랜드는 1개 이상 입력해야 합니다.")
-        List<String> interestedBrands
+        List<Long> interestedBrands
 
 ) {}

--- a/src/main/java/com/ureca/uhyu/domain/user/dto/request/UserOnboardingRequest.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/dto/request/UserOnboardingRequest.java
@@ -21,7 +21,7 @@ public record UserOnboardingRequest(
 
         @Schema(
                 description = "최근 이용한 브랜드 목록 (최소 1개 이상)",
-                example = "[\"스타벅스\", \"맥도날드\", \"버거킹\"]",
+                example = "[\"1\", \"2\", \"7\"]",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
         @NotEmpty(message = "최근 이용 브랜드는 1개 이상 입력해야 합니다.")
@@ -29,7 +29,7 @@ public record UserOnboardingRequest(
 
         @Schema(
                 description = "관심 있는 브랜드 목록 (최소 1개 이상)",
-                example = "[\"투썸플레이스\", \"KFC\", \"도미노피자\"]",
+                example = "[\"4\", \"9\"]",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
         @NotEmpty(message = "관심 있는 브랜드는 1개 이상 입력해야 합니다.")

--- a/src/main/java/com/ureca/uhyu/domain/user/service/UserService.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/service/UserService.java
@@ -105,10 +105,10 @@ public class UserService {
         return UpdateUserRes.from(savedUser);
     }
 
-    private void saveUserBrandData(User user, List<String> brandNames, DataType dataType) {
-        List<Brand> brands = brandRepository.findByBrandNameIn(brandNames);
+    private void saveUserBrandData(User user, List<Long> brandIds, DataType dataType) {
+        List<Brand> brands = brandRepository.findAllById(brandIds);
 
-        if (brands.size() != brandNames.size()) {
+        if (brands.size() != brandIds.size()) {
             throw new GlobalException(ResultCode.INVALID_INPUT); // 일부 브랜드가 존재하지 않음
         }
 


### PR DESCRIPTION
## 📌 작업 개요
- 온보딩에서 입력한 브랜드 list를 String에서 Long으로 변경했습니다.

## ✨ 기타 참고 사항
- 

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 브랜드 정보를 입력할 때 이름이 아닌 브랜드 ID로 받도록 변경되었습니다.  
  * 관련 입력 필드와 내부 처리 방식이 브랜드 ID 기반으로 일괄 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->