### PR TITLE
[FEAT][UHYU-254] 브랜드 로고 이미지 저장 유틸 클래스 생성

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/brand/repository/BrandRepository.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/repository/BrandRepository.java
@@ -9,12 +9,7 @@ import java.util.Optional;
 
 public interface BrandRepository extends JpaRepository<Brand, Long>
         , BrandRepositoryCustom{
-
-    List<Brand> findByBrandNameIn(List<String> brandNames);
-
     boolean existsByBrandName(String brandName);
-
     Optional<Brand> findByIdAndDeletedFalse(Long id);
-
     List<Brand> findByCategory(Category category);
 }

--- a/src/main/java/com/ureca/uhyu/domain/map/controller/MapController.java
+++ b/src/main/java/com/ureca/uhyu/domain/map/controller/MapController.java
@@ -9,13 +9,6 @@ import com.ureca.uhyu.global.annotation.CurrentUser;
 import com.ureca.uhyu.global.response.CommonResponse;
 import com.ureca.uhyu.global.response.ResultCode;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -26,230 +19,33 @@ import java.util.List;
 @RestController
 @RequestMapping("/map")
 @RequiredArgsConstructor
-public class MapController {
+public class MapController implements MapControllerDocs{
 
     private final MapService mapService;
 
-    @Operation(
-            summary = "지도 매장 검색",
-            description = """
-                    지도에서 매장을 검색하고 필터링합니다.
-                    
-                    **검색 조건:**
-                    - **lat, lon**: 중심 좌표 (위도, 경도)
-                    - **radius**: 검색 반경 (미터 단위)
-                    - **category**: 카테고리별 필터링 (선택) - 부분 문자열 검색
-                    - **brand**: 브랜드명 필터링 (선택) - 부분 문자열 검색
-                    
-                    **카테고리 예시:** "영화/미디어", "쇼핑"
-                    **브랜드 예시:** "CGV", "롯데시네마", "메가박스"
-                    
-                    **인증:** 불필요 (공개 API)
-                    """
-    )
-    @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "매장 검색 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = CommonResponse.class),
-                            examples = @ExampleObject(
-                                    name = "매장 검색 성공 예시",
-                                    value = """
-                                            {
-                                              "statusCode": 0,
-                                              "message": "정상 처리 되었습니다.",
-                                              "data": [
-                                                {
-                                                  "storeId": 1,
-                                                  "storeName": "CGV 동대문",
-                                                  "categoryName": "영화/미디어",
-                                                  "addressDetail": "서울특별시 중구 장충단로13길 20",
-                                                  "benefit": null,
-                                                  "logo_image": "https://example.com/logo.jpg",
-                                                  "brandName": "CGV",
-                                                  "latitude": 37.5687346,
-                                                  "longitude": 127.0076665
-                                                }
-                                              ]
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "잘못된 요청 파라미터",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = CommonResponse.class)
-                    )
-            )
-    })
     @GetMapping("/stores")
     public CommonResponse<List<MapRes>> getFilteredStores(
-            @Parameter(
-                    description = "중심 위도",
-                    example = "36.1234"
-            ) @RequestParam Double lat,
-            @Parameter(
-                    description = "중심 경도",
-                    example = "129.5678"
-            ) @RequestParam Double lon,
-            @Parameter(
-                    description = "검색 반경 (미터)",
-                    example = "1000"
-            ) @RequestParam Double radius,
-            @Parameter(
-                    description = "카테고리 필터 (부분 문자열 검색)",
-                    example = "카페"
-            ) @RequestParam(required = false) String category,
-            @Parameter(
-                    description = "브랜드명 필터 (부분 문자열 검색)",
-                    example = "스타벅스"
-            ) @RequestParam(required = false) String brand
+            @RequestParam Double lat,
+            @RequestParam Double lon,
+            @RequestParam Double radius,
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) String brand
     ) {
         return CommonResponse.success(ResultCode.SUCCESS, mapService.getFilteredStores(lat, lon, radius, category, brand));
     }
 
-    @Operation(
-            summary = "매장 상세정보 조회",
-            description = """
-                    지도 마커를 클릭했을 때 매장의 상세 정보를 조회합니다.
-                    
-                    **포함 정보:**
-                    - 등급별 혜택 정보
-                    - 제공 횟수
-                    - 이용 방법
-                    - 즐겨찾기 상태
-                    
-                    **인증 필요:** JWT Bearer Token
-                    """,
-            security = @SecurityRequirement(name = "bearerAuth")
-    )
-    @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "매장 상세정보 조회 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = CommonResponse.class),
-                            examples = @ExampleObject(
-                                    name = "매장 상세정보 조회 성공 예시",
-                                    value = """
-                                            {
-                                              "statusCode": 0,
-                                              "message": "정상 처리 되었습니다.",
-                                              "data": {
-                                                "storeName": "CGV 동대문",
-                                                "isFavorite": true,
-                                                "favoriteCount": 5,
-                                                "benefits": {
-                                                  "grade": "VIP",
-                                                  "benefitText": "학생 할인 10%"
-                                                },
-                                                "usageLimit": "월 5회",
-                                                "usageMethod": "학생증 제시"
-                                              }
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "매장을 찾을 수 없음",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = CommonResponse.class)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "401",
-                    description = "인증 실패",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = CommonResponse.class)
-                    )
-            )
-    })
     @GetMapping("/detail/stores/{storeId}")
     public CommonResponse<StoreDetailRes> getStoreDetail(
-            @Parameter(
-                    description = "매장 ID",
-                    example = "1"
-            ) @PathVariable Long storeId,
-            @Parameter(
-                    description = "현재 로그인된 사용자 정보",
-                    hidden = true
-            ) @CurrentUser User user
+            @PathVariable Long storeId,
+            @CurrentUser User user
     ){
         return CommonResponse.success(mapService.getStoreDetail(storeId,user));
     }
 
-    @Operation(
-            summary = "매장 즐겨찾기 토글",
-            description = """
-                    매장 상세정보에서 즐겨찾기 상태를 토글합니다.
-                    
-                    **동작:**
-                    - 즐겨찾기가 되어있지 않으면 추가
-                    - 즐겨찾기가 되어있으면 삭제
-                    
-                    **인증 필요:** JWT Bearer Token
-                    """,
-            security = @SecurityRequirement(name = "bearerAuth")
-    )
-    @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "즐겨찾기 토글 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = CommonResponse.class),
-                            examples = @ExampleObject(
-                                    name = "즐겨찾기 토글 성공 예시",
-                                    value = """
-                                            {
-                                              "statusCode": 0,
-                                              "message": "정상 처리 되었습니다.",
-                                              "data": {
-                                                "storeId": 1,
-                                                "isBookmarked": true
-                                              }
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "매장을 찾을 수 없음",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = CommonResponse.class)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "401",
-                    description = "인증 실패",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = CommonResponse.class)
-                    )
-            )
-    })
     @PostMapping("/{storeId}")
     public CommonResponse<MapBookmarkRes> toggleBookmark(
-            @Parameter(
-                    description = "매장 ID",
-                    example = "1"
-            ) @PathVariable Long storeId,
-            @Parameter(
-                    description = "현재 로그인된 사용자 정보",
-                    hidden = true
-            ) @CurrentUser User user
+            @PathVariable Long storeId,
+            @CurrentUser User user
     ) {
         return CommonResponse.success(mapService.toggleBookmark(user, storeId));
     }

--- a/src/main/java/com/ureca/uhyu/domain/map/controller/MapControllerDocs.java
+++ b/src/main/java/com/ureca/uhyu/domain/map/controller/MapControllerDocs.java
@@ -1,0 +1,252 @@
+package com.ureca.uhyu.domain.map.controller;
+
+import com.ureca.uhyu.domain.map.dto.response.MapBookmarkRes;
+import com.ureca.uhyu.domain.map.dto.response.MapRes;
+import com.ureca.uhyu.domain.store.dto.response.StoreDetailRes;
+import com.ureca.uhyu.domain.user.entity.User;
+import com.ureca.uhyu.global.annotation.CurrentUser;
+import com.ureca.uhyu.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+public interface MapControllerDocs {
+
+    @Operation(
+            summary = "지도 매장 검색",
+            description = """
+                    지도에서 매장을 검색하고 필터링합니다.
+                    
+                    **검색 조건:**
+                    - **lat, lon**: 중심 좌표 (위도, 경도)
+                    - **radius**: 검색 반경 (미터 단위)
+                    - **category**: 카테고리별 필터링 (선택) - 부분 문자열 검색
+                    - **brand**: 브랜드명 필터링 (선택) - 부분 문자열 검색
+                    
+                    **카테고리 예시:** "영화/미디어", "쇼핑"
+                    **브랜드 예시:** "CGV", "롯데시네마", "메가박스"
+                    
+                    **인증:** 불필요 (공개 API)
+                    """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "매장 검색 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(
+                                    name = "매장 검색 성공 예시",
+                                    value = """
+                                            {
+                                              "statusCode": 0,
+                                              "message": "정상 처리 되었습니다.",
+                                              "data": [
+                                                {
+                                                  "storeId": 1,
+                                                  "storeName": "CGV 동대문",
+                                                  "categoryName": "영화/미디어",
+                                                  "addressDetail": "서울특별시 중구 장충단로13길 20",
+                                                  "benefit": null,
+                                                  "logo_image": "https://example.com/logo.jpg",
+                                                  "brandName": "CGV",
+                                                  "latitude": 37.5687346,
+                                                  "longitude": 127.0076665
+                                                }
+                                              ]
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 파라미터",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CommonResponse.class)
+                    )
+            )
+    })
+    @GetMapping("/stores")
+    public CommonResponse<List<MapRes>> getFilteredStores(
+            @Parameter(
+                    description = "중심 위도",
+                    example = "36.1234"
+            ) @RequestParam Double lat,
+            @Parameter(
+                    description = "중심 경도",
+                    example = "129.5678"
+            ) @RequestParam Double lon,
+            @Parameter(
+                    description = "검색 반경 (미터)",
+                    example = "1000"
+            ) @RequestParam Double radius,
+            @Parameter(
+                    description = "카테고리 필터 (부분 문자열 검색)",
+                    example = "카페"
+            ) @RequestParam(required = false) String category,
+            @Parameter(
+                    description = "브랜드명 필터 (부분 문자열 검색)",
+                    example = "스타벅스"
+            ) @RequestParam(required = false) String brand
+    );
+
+    @Operation(
+            summary = "매장 상세정보 조회",
+            description = """
+                    지도 마커를 클릭했을 때 매장의 상세 정보를 조회합니다.
+                    
+                    **포함 정보:**
+                    - 등급별 혜택 정보
+                    - 제공 횟수
+                    - 이용 방법
+                    - 즐겨찾기 상태
+                    
+                    **인증 필요:** JWT Bearer Token
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "매장 상세정보 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(
+                                    name = "매장 상세정보 조회 성공 예시",
+                                    value = """
+                                            {
+                                              "statusCode": 0,
+                                              "message": "정상 처리 되었습니다.",
+                                              "data": {
+                                                "storeName": "CGV 동대문",
+                                                "isFavorite": true,
+                                                "favoriteCount": 5,
+                                                "benefits": {
+                                                  "grade": "VIP",
+                                                  "benefitText": "학생 할인 10%"
+                                                },
+                                                "usageLimit": "월 5회",
+                                                "usageMethod": "학생증 제시"
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "매장을 찾을 수 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CommonResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CommonResponse.class)
+                    )
+            )
+    })
+    @GetMapping("/detail/stores/{storeId}")
+    public CommonResponse<StoreDetailRes> getStoreDetail(
+            @Parameter(
+                    description = "매장 ID",
+                    example = "1"
+            ) @PathVariable Long storeId,
+            @Parameter(
+                    description = "현재 로그인된 사용자 정보",
+                    hidden = true
+            ) @CurrentUser User user
+    );
+
+    @Operation(
+            summary = "매장 즐겨찾기 토글",
+            description = """
+                    매장 상세정보에서 즐겨찾기 상태를 토글합니다.
+                    
+                    **동작:**
+                    - 즐겨찾기가 되어있지 않으면 추가
+                    - 즐겨찾기가 되어있으면 삭제
+                    
+                    **인증 필요:** JWT Bearer Token
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "즐겨찾기 토글 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(
+                                    name = "즐겨찾기 토글 성공 예시",
+                                    value = """
+                                            {
+                                              "statusCode": 0,
+                                              "message": "정상 처리 되었습니다.",
+                                              "data": {
+                                                "storeId": 1,
+                                                "isBookmarked": true
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "매장을 찾을 수 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CommonResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CommonResponse.class)
+                    )
+            )
+    })
+    @PostMapping("/{storeId}")
+    public CommonResponse<MapBookmarkRes> toggleBookmark(
+            @Parameter(
+                    description = "매장 ID",
+                    example = "1"
+            ) @PathVariable Long storeId,
+            @Parameter(
+                    description = "현재 로그인된 사용자 정보",
+                    hidden = true
+            ) @CurrentUser User user
+    );
+
+    @Operation(summary = "추천 매장 조회", description = "사용자의 추천 브랜드에 해당하는 근처 매장 조회")
+    @GetMapping("/recommendation/stores")
+    public CommonResponse<List<MapRes>> getRecommendedStores(
+            @RequestParam Double lat,
+            @RequestParam Double lon,
+            @RequestParam Double radius,
+            @CurrentUser User user
+    );
+}

--- a/src/main/java/com/ureca/uhyu/domain/map/dto/response/MapRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/map/dto/response/MapRes.java
@@ -23,7 +23,7 @@ public record MapRes(
         String benefit,
 
         @Schema(description = "로고 이미지")
-        String logo_image,
+        String logoImage,
 
         @Schema(description = "브랜드 이름")
         String brandName,

--- a/src/main/java/com/ureca/uhyu/domain/map/service/MapService.java
+++ b/src/main/java/com/ureca/uhyu/domain/map/service/MapService.java
@@ -12,6 +12,5 @@ public interface MapService {
     List<MapRes> getFilteredStores(Double lat, Double lon, Double radius, String category, String brand);
     StoreDetailRes getStoreDetail(Long storeId, User user);
     MapBookmarkRes toggleBookmark(User user, Long storeId);
-
     List<MapRes> findRecommendedStores(Double lat, Double lon, Double radius, User user);
 }

--- a/src/main/java/com/ureca/uhyu/domain/user/service/BarcodeServiceImpl.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/service/BarcodeServiceImpl.java
@@ -23,7 +23,7 @@ public class BarcodeServiceImpl implements BarcodeService {
     @Override
     @Transactional
     public String upload(User user, MultipartFile image) {
-        String key = s3Uploader.upload(image, FOLDER);
+        String key = s3Uploader.uploadBarcode(image, FOLDER);
 
         Barcode barcode = Barcode.builder()
                 .user(user)
@@ -43,7 +43,7 @@ public class BarcodeServiceImpl implements BarcodeService {
 
         s3Uploader.delete(barcode.getImageURL());
 
-        String newUrl = s3Uploader.upload(image, FOLDER);
+        String newUrl = s3Uploader.uploadBarcode(image, FOLDER);
 
         barcode.updateImageUrl(newUrl);
         return s3Uploader.generatePresignedUrl(newUrl);

--- a/src/main/java/com/ureca/uhyu/global/util/S3Uploader.java
+++ b/src/main/java/com/ureca/uhyu/global/util/S3Uploader.java
@@ -31,7 +31,7 @@ public class S3Uploader {
 
     private static final Set<String> ALLOWED_EXTENSIONS = Set.of("jpg", "jpeg", "png", "gif");
 
-    public String upload(MultipartFile file, String folderName) {
+    public String uploadBarcode(MultipartFile file, String folderName) {
         String originalName = file.getOriginalFilename();
         validateFileExtension(originalName);
 

--- a/src/main/java/com/ureca/uhyu/script/BrandLogoSqlGenerator.java
+++ b/src/main/java/com/ureca/uhyu/script/BrandLogoSqlGenerator.java
@@ -41,10 +41,18 @@ public class BrandLogoSqlGenerator implements CommandLineRunner {
 
     @Override
     public void run(String... args) {
-        List<S3Object> objects = s3Client.listObjectsV2(ListObjectsV2Request.builder()
-                .bucket(BUCKET_NAME)
-                .prefix(FOLDER_PREFIX)
-                .build()).contents();
+
+
+        List<S3Object> objects;
+
+        try {
+            objects= s3Client.listObjectsV2(ListObjectsV2Request.builder()
+                    .bucket(BUCKET_NAME)
+                    .prefix(FOLDER_PREFIX)
+                    .build()).contents();
+        }catch (Exception e){
+            throw new RuntimeException("S3 객체 목록 조회 중 오류 발생", e);
+        }
 
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(OUTPUT_FILE, StandardCharsets.UTF_8))) {
             for (S3Object obj : objects) {

--- a/src/main/java/com/ureca/uhyu/script/BrandLogoSqlGenerator.java
+++ b/src/main/java/com/ureca/uhyu/script/BrandLogoSqlGenerator.java
@@ -1,0 +1,87 @@
+package com.ureca.uhyu.script;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.text.Normalizer;
+import java.util.List;
+
+//@Component
+@Slf4j
+@RequiredArgsConstructor
+public class BrandLogoSqlGenerator implements CommandLineRunner {
+
+    private static final String BUCKET_NAME = "uhyu-bucket";
+    private static final String REGION = "ap-northeast-2";
+    private static final String FOLDER_PREFIX = "logo/";
+    private static final String[] EXTENSIONS = {"png", "jpg", "jpeg"};
+    private static final String OUTPUT_FILE = "logo_update.sql";
+
+    private static final AwsBasicCredentials credentials = AwsBasicCredentials.create(
+            System.getenv("AWS_ACCESS_KEY"),
+            System.getenv("AWS_SECRET_KEY")
+    );
+
+    private final S3Client s3Client = S3Client.builder()
+            .region(Region.of(REGION))
+            .credentialsProvider(StaticCredentialsProvider.create(credentials))
+            .build();
+
+    @Override
+    public void run(String... args) {
+        List<S3Object> objects = s3Client.listObjectsV2(ListObjectsV2Request.builder()
+                .bucket(BUCKET_NAME)
+                .prefix(FOLDER_PREFIX)
+                .build()).contents();
+
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(OUTPUT_FILE, StandardCharsets.UTF_8))) {
+            for (S3Object obj : objects) {
+                String key = obj.key(); // 예: logo/스타벅스.png
+
+                String fileName = key.replaceFirst(FOLDER_PREFIX, "");
+                int dotIdx = fileName.lastIndexOf(".");
+                if (dotIdx == -1) continue;
+
+                String brandNameRaw = fileName.substring(0, dotIdx);
+                String ext = fileName.substring(dotIdx + 1).toLowerCase();
+
+                boolean valid = false;
+                for (String e : EXTENSIONS) {
+                    if (e.equals(ext)) {
+                        valid = true;
+                        break;
+                    }
+                }
+                if (!valid) continue;
+
+                // NFC 정규화 (완성형 보장)
+                String brandName = Normalizer.normalize(brandNameRaw, Normalizer.Form.NFC);
+
+                String encodedKey = URLEncoder.encode(key, StandardCharsets.UTF_8)
+                        .replace("+", "%20")
+                        .replace("%2F", "/");
+
+                String imageUrl = String.format("https://%s.s3.%s.amazonaws.com/%s", BUCKET_NAME, REGION, encodedKey);
+
+                String sql = String.format("UPDATE brands SET logo_image = '%s' WHERE brand_name = '%s';", imageUrl, brandName);
+                writer.write(sql);
+                writer.newLine();
+            }
+            writer.flush();
+        } catch (IOException e) {
+            throw new RuntimeException("SQL 파일 저장 중 오류 발생", e);
+        }
+    }
+}


### PR DESCRIPTION
## 📌 작업 개요

- 로고 이미지 저장을 위해서 S3에 있는 이미지 목록으로 저장하는 유틸 클래스를 만들었습니다.
- BrandLogoSqlGenerator 코드 확인하시면 됩니다. 

## ✨ 기타 참고 사항

- 해당 로직은 uhyu/script 폴더를 만들어서 유틸 클래스들을 배치할 예정입니다.

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서화**
  * 지도 관련 API의 Swagger/OpenAPI 문서가 별도의 인터페이스로 분리되어, API 명세가 개선되었습니다.

* **신규 기능**
  * 브랜드 로고 이미지를 AWS S3에서 읽어와 SQL 업데이트 스크립트를 생성하는 도구가 추가되었습니다.

* **리팩토링**
  * S3 이미지 업로드 메서드명이 명확하게 변경되어, 바코드 이미지 업로드에 특화된 메서드를 사용하도록 개선되었습니다.
  * 지도 API 응답 필드명이 스네이크 케이스에서 카멜 케이스로 변경되었습니다.

* **기타**
  * 사용되지 않는 브랜드 조회 메서드가 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->