### PR TITLE
[REFACTER][UHYU-265] markd 제거 및 유저 방문 및 관심 브랜드 erd 수정 반영

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/recommendation/entity/RecommendationBaseData.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/entity/RecommendationBaseData.java
@@ -7,6 +7,10 @@ import com.ureca.uhyu.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+/**
+ * 사용자가 온보딩에서 입력하거나 마이페이지에서 수정한 관심 브랜드
+ */
+
 @Entity
 @Table(name = "recommendation_base_data")
 @Getter

--- a/src/main/java/com/ureca/uhyu/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/ureca/uhyu/domain/store/repository/StoreRepository.java
@@ -1,7 +1,11 @@
 package com.ureca.uhyu.domain.store.repository;
 
+import com.ureca.uhyu.domain.brand.entity.Brand;
 import com.ureca.uhyu.domain.store.entity.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface StoreRepository extends JpaRepository<Store, Long> {
+    List<Store> findAllByBrand(Brand brand);
 }

--- a/src/main/java/com/ureca/uhyu/domain/user/dto/response/GetUserInfoRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/dto/response/GetUserInfoRes.java
@@ -16,7 +16,6 @@ public record GetUserInfoRes(
         Integer age,
         Gender gender,
         Grade grade,
-        Long markerId,
         LocalDateTime updatedAt
 ) {
     public static GetUserInfoRes from(User user){
@@ -28,7 +27,6 @@ public record GetUserInfoRes(
                 user.getAge(),
                 user.getGender(),
                 user.getGrade(),
-                user.getMarkerId(),
                 user.getUpdatedAt()
         );
     }

--- a/src/main/java/com/ureca/uhyu/domain/user/entity/History.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/entity/History.java
@@ -1,5 +1,6 @@
 package com.ureca.uhyu.domain.user.entity;
 
+import com.ureca.uhyu.domain.brand.entity.Brand;
 import com.ureca.uhyu.domain.store.entity.Store;
 import jakarta.persistence.*;
 import lombok.*;
@@ -28,6 +29,10 @@ public class History {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id")
     private Store store;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "brand_id")
+    private Brand brand;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/java/com/ureca/uhyu/domain/user/entity/User.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/entity/User.java
@@ -52,8 +52,6 @@ public class User extends BaseEntity {
     @Column(length = 20)
     private String age_range;
 
-    private Long markerId;
-
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private Barcode barcode;
 
@@ -67,12 +65,11 @@ public class User extends BaseEntity {
     }
 
     public void updateUser(
-            String profileImage, String nickname, Grade grade, Long markerId
+            String profileImage, String nickname, Grade grade
     ){
         this.profileImage = profileImage;
         this.nickname = nickname;
         this.grade = grade;
-        this.markerId = markerId;
     }
 
     public void setUserGrade(Grade grade) {


### PR DESCRIPTION
## 📌 작업 개요
- 기존에는 온보딩 시 입력받은 방문 브랜드와 관심 브랜드 모두 RecommendationBaseData 테이블에 저장했으나, 현재는 온보딩에서 입력한 방문 브랜드 역시 History 테이블에 저장되도록 구조를 변경했습니다.
- 관심 브랜드는 여전히 RecommendationBaseData 테이블에 INTEREST 타입으로 저장됩니다.
- 따라서 방문 브랜드(매장)과 관심 브랜드의 테이블을 분리함으로써 데이터의 의미와 역할을 명확하게 분리했습니다.
- 중복되던 History 저장 로직(benefitPrice 계산 포함)을 saveHistory() 메서드로 분리하여 saveRecentBrandsToHistory() 및 saveVisitedBrand()에서 공통 사용하도록 리팩토링했습니다.

## ✨ 기타 참고 사항
- 온보딩에서 입력한 이전 방문 브랜드는 history 테이블, 관심 브랜드는 recommendation_base_data 테이블에 저장됩니다.
- recommendation_base_data 테이블 명은 추후 변경 예정입니다.

## ✅ PR 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [ ] 로컬 서버에서 정상 동작을 확인했어요.
- [ ] 불필요한 코드/주석 삭제했어요.
