### PR TITLE
[FEAT][UHYU-282] 모니터링 시스템 도입을 위한 Prometheus와 Grafana 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,10 @@ dependencies {
 	implementation platform('software.amazon.awssdk:bom:2.25.25')
 	implementation 'software.amazon.awssdk:s3'
 	implementation 'software.amazon.awssdk:auth'
+
+	// Monitoring
+	implementation("org.springframework.boot:spring-boot-starter-actuator")
+	implementation("io.micrometer:micrometer-registry-prometheus")
 }
 
 tasks.named('test') {

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -1,0 +1,40 @@
+version: '3.7'
+
+services:
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    networks:
+      - monitor-net
+
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+    networks:
+      - monitor-net
+
+  postgres-exporter:
+    image: wrouesnel/postgres_exporter
+    container_name: postgres-exporter
+    ports:
+      - "9187:9187"
+    env_file:
+      - .env
+    environment:
+      - DATA_SOURCE_NAME=postgresql://${SPRING_DATASOURCE_USERNAME}:${SPRING_DATASOURCE_PASSWORD}@${EXPORTER_DB_HOST}?sslmode=disable
+    networks:
+      - monitor-net
+
+networks:
+  monitor-net:
+    driver: bridge

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'spring'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8080']  # EC2에서 Docker → EC2 host
+
+  - job_name: 'pgexporter'
+    static_configs:
+      - targets: ['postgres-exporter:9187']

--- a/src/main/java/com/ureca/uhyu/global/config/PermitAllURI.java
+++ b/src/main/java/com/ureca/uhyu/global/config/PermitAllURI.java
@@ -12,7 +12,8 @@ public enum PermitAllURI {
     SWAGGER("/swagger-ui"),
     DOCS("/v3/api-docs"),
     ROOT("/"),
-    BRAND_LIST("/brand-list");
+    BRAND_LIST("/brand-list"),
+    PROMETHEUS("/actuator/prometheus");
 
     private final String uri;
 

--- a/src/main/java/com/ureca/uhyu/global/config/SecurityConfig.java
+++ b/src/main/java/com/ureca/uhyu/global/config/SecurityConfig.java
@@ -78,7 +78,7 @@ public class SecurityConfig {
                                 "/", "/login", "/oauth2/**",
                                 "/swagger-ui/**", "/v3/api-docs/**",
                                 "/brand-list/**",
-                                "/map/stores"
+                                "/map/stores","/actuator/prometheus"
                         ).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/admin/**")).hasRole("ADMIN")
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,12 @@ app:
     url:
       local: http://localhost:5173
       prod: https://www.u-hyu.site
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+  metrics:
+    tags:
+      application: uhyu-server


### PR DESCRIPTION
## 📌 작업 개요
- Spring 서버와 Postgresql DB의 메트릭을 수집, 저장을 하기 위한 Prometheus 도입
- Prometheus는 이 메트릭을 HTTP를 통한 pull model 방식으로 주기적으로 수집하여 시계열 데이터로 저장
<br></br>
- Prometheus를 Data Source로 수집된 메트릭과 데이터를 시각화하기 위한 Grafana 도입
- Prometheus가 기본적으로 제공하는 시각화보다 훨씬 효과적인 시각화 제공

## ✨ 기타 참고 사항

- **.env 파일 수정이 있습니다** 
- 모니터링 도입 후에 배포 서버에 대한 성능 확인을 할 예정입니다.

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.
