### PR TITLE
[UHYU-293] fix: 추천 테이블 category_id 속성 삭제

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/recommendation/entity/Recommendation.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/entity/Recommendation.java
@@ -23,10 +23,6 @@ public class Recommendation extends BaseEntity {
     @JoinColumn(name = "brand_id")
     private Brand brand;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "category_id")
-    private Category category;
-
     @Column(name = "score")
     private Long score;
 

--- a/src/main/resources/db/changelog/2025/07/29-02-changelog.xml
+++ b/src/main/resources/db/changelog/2025/07/29-02-changelog.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.29.xsd"
+        objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+    <changeSet id="1753763727926-1" author="sowon">
+        <dropForeignKeyConstraint baseTableName="recommendation" constraintName="fk_recommendation_on_category"/>
+    </changeSet>
+    <changeSet id="1753763727926-3" author="sowon">
+        <dropColumn columnName="category_id" tableName="recommendation"/>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## 📌 작업 개요
- 추천 결과 저장하는 recommendation table에 category_id 속성 제거 

## ✨ 기타 참고 사항
- 

## ✅ PR 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [ ] 로컬 서버에서 정상 동작을 확인했어요.
- [ ] 불필요한 코드/주석 삭제했어요.
