### PR TITLE
[FIX][UHYU-294] 어드민 브랜드 수정 에러 코드 수정

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/brand/dto/request/UpdateBrandReq.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/dto/request/UpdateBrandReq.java
@@ -7,7 +7,6 @@ import com.ureca.uhyu.domain.user.enums.Grade;
 import java.util.List;
 
 public record UpdateBrandReq(
-        Long brandId,
         String brandName,
         String brandImg,
         List<BenefitDto> data, // grade, benefit 리스트

--- a/src/main/java/com/ureca/uhyu/domain/brand/service/BrandService.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/service/BrandService.java
@@ -137,7 +137,9 @@ public class BrandService {
                         .build())
                 .toList();
 
-        brand.setBenefits(updateBenefits);
+//        brand.setBenefits(updateBenefits);
+        brand.getBenefits().clear();
+        brand.getBenefits().addAll(updateBenefits);
 
         return new CreateUpdateBrandRes(brand.getId());
     }


### PR DESCRIPTION
## 📌 작업 개요
- 브랜드 수정 API에서 Benefit 리스트 업데이트 시 발생하던 orphanRemoval 관련 예외를 해결했습니다.
- Brand 엔티티의 benefits 컬렉션을 완전히 교체하지 않고 clear() → addAll() 방식으로 갱신하여 JPA 참조 무결성을 유지했습니다.

## ✨ 기타 참고 사항
<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.
