### PR TITLE
[FEAT][UHYU-275] 선호 브랜드 목록 조회

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/brand/controller/BrandController.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/controller/BrandController.java
@@ -1,5 +1,6 @@
 package com.ureca.uhyu.domain.brand.controller;
 
+import com.ureca.uhyu.domain.brand.dto.response.InterestBrandRes;
 import com.ureca.uhyu.domain.brand.dto.response.BrandInfoRes;
 import com.ureca.uhyu.domain.brand.dto.response.BrandListRes;
 import com.ureca.uhyu.domain.brand.service.BrandService;
@@ -191,5 +192,10 @@ public class BrandController {
                     example = "1"
             ) @PathVariable(name = "brand_id") Long brandId){
         return CommonResponse.success(brandService.findBrandInfo(brandId));
+    }
+
+    @GetMapping("/brand-list/interest")
+    public CommonResponse<List<InterestBrandRes>> getInterestBrandList(){
+        return CommonResponse.success(brandService.findInterestBrandList());
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/brand/controller/BrandController.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/controller/BrandController.java
@@ -194,6 +194,7 @@ public class BrandController {
         return CommonResponse.success(brandService.findBrandInfo(brandId));
     }
 
+    @Operation(summary = "선호 브랜드 목록 조회", description = "온보딩, 개인정보 수정 시 고를 브랜드 목록 조회 (카테고리당 1개)")
     @GetMapping("/brand-list/interest")
     public CommonResponse<List<InterestBrandRes>> getInterestBrandList(){
         return CommonResponse.success(brandService.findInterestBrandList());

--- a/src/main/java/com/ureca/uhyu/domain/brand/dto/response/InterestBrandRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/dto/response/InterestBrandRes.java
@@ -1,0 +1,17 @@
+package com.ureca.uhyu.domain.brand.dto.response;
+
+import com.ureca.uhyu.domain.brand.entity.Brand;
+
+public record InterestBrandRes (
+        Long brandId,
+        String brandName,
+        String logoImage
+){
+    public static InterestBrandRes from(Brand brand){
+        return new InterestBrandRes(
+                brand.getId(),
+                brand.getBrandName(),
+                brand.getLogoImage()
+        );
+    }
+}

--- a/src/main/java/com/ureca/uhyu/domain/brand/repository/BrandRepository.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/repository/BrandRepository.java
@@ -4,7 +4,6 @@ import com.ureca.uhyu.domain.brand.entity.Brand;
 import com.ureca.uhyu.domain.brand.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 

--- a/src/main/java/com/ureca/uhyu/domain/brand/repository/BrandRepository.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/repository/BrandRepository.java
@@ -4,6 +4,7 @@ import com.ureca.uhyu.domain.brand.entity.Brand;
 import com.ureca.uhyu.domain.brand.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -12,4 +13,6 @@ public interface BrandRepository extends JpaRepository<Brand, Long>
     boolean existsByBrandName(String brandName);
     Optional<Brand> findByIdAndDeletedFalse(Long id);
     List<Brand> findByCategory(Category category);
+
+    List<Brand> findByIdIn(List<Long> ids);
 }

--- a/src/main/java/com/ureca/uhyu/domain/brand/service/BrandService.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/service/BrandService.java
@@ -152,6 +152,9 @@ public class BrandService {
     }
 
     public List<InterestBrandRes> findInterestBrandList() {
-
+        // 각 카테고리를 대표하는 브랜드들의 id 입력, 베포 db 기준이라 로컬에서는 에러가 날 수도
+        List<Long> recommendIdList = List.of(95L, 2L, 10L, 15L, 25L, 30L, 35L, 39L, 55L, 71L, 83L, 101L, 110L, 118L);
+        List<Brand> brandList = brandRepository.findByIdIn(recommendIdList);
+        return brandList.stream().map(InterestBrandRes::from).toList();
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/brand/service/BrandService.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/service/BrandService.java
@@ -148,4 +148,8 @@ public class BrandService {
                 .orElseThrow(() -> new GlobalException(ResultCode.BRAND_NOT_FOUND));
         brand.markDeleted();
     }
+
+    public List<InterestBrandRes> findInterestBrandList() {
+
+    }
 }


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 사용자가 선호 브랜드를 고를 때, 혹은 수정할 때 보여줄 선호 브랜드들의 목록을 조회하는 api 구현
- 해당 기능을 위한 dto 생성
- 해당 기능 검증을 위한 단위 테스트 작성

## ✨ 기타 참고 사항
<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 선호 브랜드 목록을 조회할 수 있는 새로운 API가 추가되었습니다. (온보딩 및 개인정보 수정 시 사용)
* **버그 수정**
  * 브랜드 삭제 관련 테스트 중복이 제거되었습니다.
* **테스트**
  * 선호 브랜드 목록 조회 및 브랜드 삭제에 대한 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->