### PR TITLE
[FEATURE][UHYU-102] 비로그인 사용자 대상 인기 브랜드 Top3 제공 api 기능 구현, guest 도메인 분리

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/brand/controller/BrandController.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/controller/BrandController.java
@@ -26,72 +26,12 @@ import java.util.List;
 @Tag(name = "브랜드/제휴점", description = "제휴점 목록 조회 및 상세 정보 관련 API")
 @RestController
 @RequiredArgsConstructor
-public class BrandController {
+public class BrandController implements BrandControllerDocs {
 
     private final BrandService brandService;
 
+    @Override
     @GetMapping("/brand-list")
-    @Operation(
-            summary = "제휴처 목록 조회",
-            description = """
-                    제휴처 목록을 조회합니다. 다양한 필터링 옵션을 지원합니다.
-                    
-                    **필터링 옵션:**
-                    - **category**: 카테고리별 필터링
-                    - **storeType**: 매장 타입별 필터링 (복수 선택 가능)
-                    - **benefitType**: 혜택 타입별 필터링 (복수 선택 가능)
-                    - **brand_name**: 브랜드명 검색
-                    
-                    **카테고리 예시:** "영화/미디어", "쇼핑"
-                    **브랜드 예시:** "CGV", "롯데시네마", "메가박스"
-                    
-                    **페이징:**
-                    - **page**: 페이지 번호 (0부터 시작)
-                    - **size**: 페이지당 항목 수 (1-100)
-                    
-                    **인증:** 불필요 (공개 API)
-                    """
-    )
-    @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "제휴처 목록 조회 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = CommonResponse.class),
-                            examples = @ExampleObject(
-                                    name = "제휴처 목록 조회 성공 예시",
-                                    value = """
-                                            {
-                                              "statusCode": 0,
-                                              "message": "정상 처리 되었습니다.",
-                                              "data": {
-                                                "brandList": [
-                                                  {
-                                                    "brandId": 2,
-                                                    "brandName": "CGV",
-                                                    "logoImage": "https://example.com/logo.jpg",
-                                                    "description": "VVIP : 학생 할인 15%, VIP : 학생 할인 10%, 우수 : 기본 할인 5%"
-                                                  }
-                                                ],
-                                                "hasNext": true,
-                                                "totalPages": 5,
-                                                "currentPage": 0
-                                              }
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "잘못된 요청 파라미터",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = CommonResponse.class)
-                    )
-            )
-    })
     public CommonResponse<BrandListRes> getBrands(
             @Parameter(
                     description = "카테고리 필터",
@@ -123,68 +63,7 @@ public class BrandController {
         );
     }
 
-    @Operation(
-            summary = "제휴처 상세 조회",
-            description = "특정 제휴처의 상세 정보를 조회합니다.",
-            security = @SecurityRequirement(name = "bearerAuth")
-    )
-    @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "제휴처 상세 정보 조회 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = CommonResponse.class),
-                            examples = @ExampleObject(
-                                    name = "제휴처 상세 정보 조회 성공 예시",
-                                    value = """
-                                            {
-                                              "statusCode": 0,
-                                              "message": "정상 처리 되었습니다.",
-                                              "data": {
-                                                "brandId": 2,
-                                                "brandName": "CGV",
-                                                "logoImage": "https://example.com/logo.jpg",
-                                                "usageMethod": "학생증 제시",
-                                                "usageLimit": "월 5회",
-                                                "benefitRes": [
-                                                  {
-                                                    "grade": "VIP",
-                                                    "description": "학생 할인 10%"
-                                                  }
-                                                ]
-                                              }
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "제휴처를 찾을 수 없음",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = CommonResponse.class),
-                            examples = @ExampleObject(
-                                    name = "제휴처 없음 예시",
-                                    value = """
-                                            {
-                                              "statusCode": 5001,
-                                              "message": "제휴처 정보를 찾을 수 없습니다."
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "401",
-                    description = "인증 실패",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = CommonResponse.class)
-                    )
-            )
-    })
+    @Override
     @GetMapping("/brand-list/{brand_id}")
     public CommonResponse<BrandInfoRes> getBrandInfo(
             @Parameter(
@@ -194,7 +73,7 @@ public class BrandController {
         return CommonResponse.success(brandService.findBrandInfo(brandId));
     }
 
-    @Operation(summary = "선호 브랜드 목록 조회", description = "온보딩, 개인정보 수정 시 고를 브랜드 목록 조회 (카테고리당 1개)")
+    @Override
     @GetMapping("/brand-list/interest")
     public CommonResponse<List<InterestBrandRes>> getInterestBrandList(){
         return CommonResponse.success(brandService.findInterestBrandList());

--- a/src/main/java/com/ureca/uhyu/domain/brand/controller/BrandControllerDocs.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/controller/BrandControllerDocs.java
@@ -1,0 +1,183 @@
+package com.ureca.uhyu.domain.brand.controller;
+
+import com.ureca.uhyu.domain.brand.dto.response.BrandInfoRes;
+import com.ureca.uhyu.domain.brand.dto.response.BrandListRes;
+import com.ureca.uhyu.domain.brand.dto.response.InterestBrandRes;
+import com.ureca.uhyu.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+public interface BrandControllerDocs {
+
+    @Operation(
+            summary = "제휴처 목록 조회",
+            description = """
+                    제휴처 목록을 조회합니다. 다양한 필터링 옵션을 지원합니다.
+                    
+                    **필터링 옵션:**
+                    - **category**: 카테고리별 필터링
+                    - **storeType**: 매장 타입별 필터링 (복수 선택 가능)
+                    - **benefitType**: 혜택 타입별 필터링 (복수 선택 가능)
+                    - **brand_name**: 브랜드명 검색
+                    
+                    **카테고리 예시:** "영화/미디어", "쇼핑"
+                    **브랜드 예시:** "CGV", "롯데시네마", "메가박스"
+                    
+                    **페이징:**
+                    - **page**: 페이지 번호 (0부터 시작)
+                    - **size**: 페이지당 항목 수 (1-100)
+                    
+                    **인증:** 불필요 (공개 API)
+                    """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "제휴처 목록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(
+                                    name = "제휴처 목록 조회 성공 예시",
+                                    value = """
+                                            {
+                                              "statusCode": 0,
+                                              "message": "정상 처리 되었습니다.",
+                                              "data": {
+                                                "brandList": [
+                                                  {
+                                                    "brandId": 2,
+                                                    "brandName": "CGV",
+                                                    "logoImage": "https://example.com/logo.jpg",
+                                                    "description": "VVIP : 학생 할인 15%, VIP : 학생 할인 10%, 우수 : 기본 할인 5%"
+                                                  }
+                                                ],
+                                                "hasNext": true,
+                                                "totalPages": 5,
+                                                "currentPage": 0
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 파라미터",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CommonResponse.class)
+                    )
+            )
+    })
+    CommonResponse<BrandListRes> getBrands(
+            @Parameter(
+                    description = "카테고리 필터",
+                    example = "카페"
+            ) @RequestParam(required = false) String category,
+            @Parameter(
+                    description = "매장 타입 필터 (복수 선택 가능)",
+                    example = "[\"OFFLINE\", \"ONLINE\"]"
+            ) @RequestParam(required = false) List<String> storeType,
+            @Parameter(
+                    description = "혜택 타입 필터 (복수 선택 가능)",
+                    example = "[\"DISCOUNT\", \"GIFT\"]"
+            ) @RequestParam(required = false) List<String> benefitType,
+            @Parameter(
+                    description = "브랜드명 검색",
+                    example = "스타벅스"
+            ) @RequestParam(required = false, name = "brand_name") String brandName,
+            @Parameter(
+                    description = "페이지 번호 (0부터 시작)",
+                    example = "0"
+            ) @RequestParam(defaultValue = "0") @Min(0) int page,
+            @Parameter(
+                    description = "페이지당 항목 수 (1-100)",
+                    example = "10"
+            ) @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size
+    );
+
+    @Operation(
+            summary = "제휴처 상세 조회",
+            description = "특정 제휴처의 상세 정보를 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "제휴처 상세 정보 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(
+                                    name = "제휴처 상세 정보 조회 성공 예시",
+                                    value = """
+                                            {
+                                              "statusCode": 0,
+                                              "message": "정상 처리 되었습니다.",
+                                              "data": {
+                                                "brandId": 2,
+                                                "brandName": "CGV",
+                                                "logoImage": "https://example.com/logo.jpg",
+                                                "usageMethod": "학생증 제시",
+                                                "usageLimit": "월 5회",
+                                                "benefitRes": [
+                                                  {
+                                                    "grade": "VIP",
+                                                    "description": "학생 할인 10%"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "제휴처를 찾을 수 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(
+                                    name = "제휴처 없음 예시",
+                                    value = """
+                                            {
+                                              "statusCode": 5001,
+                                              "message": "제휴처 정보를 찾을 수 없습니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CommonResponse.class)
+                    )
+            )
+    })
+    CommonResponse<BrandInfoRes> getBrandInfo(
+            @Parameter(
+                    description = "제휴처 ID",
+                    example = "1"
+            ) @PathVariable(name = "brand_id") Long brandId);
+
+    @Operation(summary = "선호 브랜드 목록 조회", description = "온보딩, 개인정보 수정 시 고를 브랜드 목록 조회 (카테고리당 1개)")
+    public CommonResponse<List<InterestBrandRes>> getInterestBrandList();
+
+}

--- a/src/main/java/com/ureca/uhyu/domain/guest/controller/GuestController.java
+++ b/src/main/java/com/ureca/uhyu/domain/guest/controller/GuestController.java
@@ -1,0 +1,35 @@
+package com.ureca.uhyu.domain.guest.controller;
+
+import com.ureca.uhyu.domain.guest.service.GuestService;
+import com.ureca.uhyu.domain.mymap.dto.response.MyMapRes;
+import com.ureca.uhyu.domain.guest.dto.response.GuestRecommendationRes;
+import com.ureca.uhyu.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "비로그인", description = "비로그인 사용자 요청 관련 API")
+@RestController
+@RequestMapping("/guest")
+@RequiredArgsConstructor
+public class GuestController implements GuestControllerDocs {
+
+    private final GuestService guestService;
+
+    @Override
+    @GetMapping("/mymap/{uuid}")
+    public CommonResponse<MyMapRes> getMyMapByUUIDWithGuest(@PathVariable String uuid) {
+        return CommonResponse.success(guestService.findMyMapByUUIDWithGuest(uuid));
+    }
+
+    @Override
+    @GetMapping("/recommendation/top3")
+    public CommonResponse<List<GuestRecommendationRes>> guestTop3Recommendation(){
+        return CommonResponse.success(guestService.getTop3PopularBrandsForGuest());
+    }
+}

--- a/src/main/java/com/ureca/uhyu/domain/guest/controller/GuestControllerDocs.java
+++ b/src/main/java/com/ureca/uhyu/domain/guest/controller/GuestControllerDocs.java
@@ -1,0 +1,130 @@
+package com.ureca.uhyu.domain.guest.controller;
+
+import com.ureca.uhyu.domain.mymap.dto.response.MyMapRes;
+import com.ureca.uhyu.domain.guest.dto.response.GuestRecommendationRes;
+import com.ureca.uhyu.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
+
+public interface GuestControllerDocs {
+
+    @Operation(
+            summary = "UUID 기반 My Map 조회(비회원)",
+            description = """
+                    비회원이 UUID를 통해 공유된 My Map의 상세 정보를 조회합니다.
+                 
+                   **특징:**
+                    - 인증 불필요 (토큰 없이 접근 가능)
+                    - 회원용 조회와 동일한 데이터 반환
+                    - 공유 목적으로 사용됨
+                   
+                    **인증 불필요:** 별도 토큰 없이 접근 가능
+                   """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "My Map 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(
+                                    name = "비회원 My Map 조회 성공 예시",
+                                    value = """
+                                           {
+                                              "statusCode": 0,
+                                              "message": "정상 처리 되었습니다.",
+                                              "data": {
+                                                "myMapListId": 1,
+                                                "title": "영화관 투어",
+                                                "markerColor": "RED",
+                                                "uuid": "550e8400-e29b-41d4-a716-446655440000",
+                                                "isMine": false,
+                                                "stores": [
+                                                  {
+                                                    "storeId": 1,
+                                                    "storeName": "CGV 동대문",
+                                                    "address": "서울특별시 중구 장충단로13길 20",
+                                                    "latitude": 37.5687346,
+                                                    "longitude": 127.0076665
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "My Map을 찾을 수 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CommonResponse.class)
+                    )
+            )
+    })
+    CommonResponse<MyMapRes> getMyMapByUUIDWithGuest(
+            @Parameter(
+                    description = "My Map UUID",
+                    example = "550e8400-e29b-41d4-a716-446655440000"
+            ) @PathVariable String uuid
+    );
+
+
+    @Operation(
+            summary = "비로그인 사용자 인기 브랜드 Top3 조회",
+            description = """
+                    전체 사용자 방문 기록을 기반으로 가장 많이 이용된 브랜드 상위 3개를 반환합니다.
+                    
+                    **추천 기준:**
+                    - 모든 사용자의 History 데이터를 기반으로 방문 수가 많은 브랜드 순서로 정렬
+                    - 브랜드명, 로고 이미지 포함
+                    
+                    **인증 불필요:** 누구나 접근 가능
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "비로그인 추천 브랜드 조회 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = CommonResponse.class),
+                    examples = @ExampleObject(
+                            name = "비로그인 인기 브랜드 Top3 예시",
+                            value = """
+                                    {
+                                      "statusCode": 0,
+                                      "message": "정상 처리 되었습니다.",
+                                      "data": [
+                                        {
+                                          "brandId": 1,
+                                          "brandName": "스타벅스",
+                                          "logoImg": "starbucks.png"
+                                        },
+                                        {
+                                          "brandId": 2,
+                                          "brandName": "투썸플레이스",
+                                          "logoImg": "twosome.png"
+                                        },
+                                        {
+                                          "brandId": 3,
+                                          "brandName": "이디야",
+                                          "logoImg": "ediya.png"
+                                        }
+                                      ]
+                                    }
+                                    """
+                    )
+            )
+    )
+    CommonResponse<List<GuestRecommendationRes>> guestTop3Recommendation();
+}

--- a/src/main/java/com/ureca/uhyu/domain/guest/dto/response/GuestRecommendationRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/guest/dto/response/GuestRecommendationRes.java
@@ -1,4 +1,4 @@
-package com.ureca.uhyu.domain.recommendation.dto.response;
+package com.ureca.uhyu.domain.guest.dto.response;
 
 public record GuestRecommendationRes (
         Long brandId,

--- a/src/main/java/com/ureca/uhyu/domain/guest/service/GuestService.java
+++ b/src/main/java/com/ureca/uhyu/domain/guest/service/GuestService.java
@@ -42,7 +42,7 @@ public class GuestService {
         List<Brand> brands = recommendationRepository.findTop3BrandByVisitCountFromHistory();
 
         if (brands == null || brands.isEmpty()) {
-            throw new GlobalException((ResultCode.BRAND_ID_IS_NULL));
+            throw new GlobalException((ResultCode.NOT_FOUND_RECOMMENDATION_FOR_USER));
         }
         return brands.stream()
                 .map(brand -> GuestRecommendationRes.from(

--- a/src/main/java/com/ureca/uhyu/domain/guest/service/GuestService.java
+++ b/src/main/java/com/ureca/uhyu/domain/guest/service/GuestService.java
@@ -1,0 +1,56 @@
+package com.ureca.uhyu.domain.guest.service;
+
+import com.ureca.uhyu.domain.brand.entity.Brand;
+import com.ureca.uhyu.domain.guest.dto.response.GuestRecommendationRes;
+import com.ureca.uhyu.domain.map.dto.response.MapRes;
+import com.ureca.uhyu.domain.mymap.dto.response.MyMapRes;
+import com.ureca.uhyu.domain.mymap.entity.MyMap;
+import com.ureca.uhyu.domain.mymap.entity.MyMapList;
+import com.ureca.uhyu.domain.mymap.repository.MyMapListRepository;
+import com.ureca.uhyu.domain.mymap.repository.MyMapRepository;
+import com.ureca.uhyu.domain.recommendation.repository.RecommendationRepository;
+import com.ureca.uhyu.global.exception.GlobalException;
+import com.ureca.uhyu.global.response.ResultCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GuestService {
+
+    private final MyMapListRepository myMapListRepository;
+    private final MyMapRepository myMapRepository;
+    private final RecommendationRepository recommendationRepository;
+
+    public MyMapRes findMyMapByUUIDWithGuest(String uuid) {
+        MyMapList myMapList = myMapListRepository.findByUuid(uuid).orElseThrow(() -> new GlobalException(ResultCode.MY_MAP_LIST_NOT_FOUND));
+        List<MyMap> myMaps = myMapRepository.findByMyMapList(myMapList);
+
+        List<MapRes> storeList = myMaps.stream()
+                .map(myMap -> MapRes.from(myMap.getStore()))
+                .toList();
+
+        return MyMapRes.from(myMapList, storeList, false);
+    }
+
+
+    public List<GuestRecommendationRes> getTop3PopularBrandsForGuest() {
+        List<Brand> brands = recommendationRepository.findTop3BrandByVisitCountFromHistory();
+
+        if (brands == null || brands.isEmpty()) {
+            throw new GlobalException((ResultCode.BRAND_ID_IS_NULL));
+        }
+        return brands.stream()
+                .map(brand -> GuestRecommendationRes.from(
+                        brand.getId(),
+                        brand.getBrandName(),
+                        brand.getLogoImage()
+                ))
+                .toList();
+    }
+
+}

--- a/src/main/java/com/ureca/uhyu/domain/mymap/controller/MyMapController.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/controller/MyMapController.java
@@ -62,12 +62,6 @@ public class MyMapController implements MyMapControllerDocs {
     }
 
 
-    @GetMapping("/guest/{uuid}")
-    public CommonResponse<MyMapRes> getMyMapByUUIDWithGuest(@PathVariable String uuid) {
-        return CommonResponse.success(myMapService.findMyMapByUUIDWithGuest(uuid));
-    }
-
-
     @GetMapping("/list/{store_id}")
     public CommonResponse<BookmarkedMyMapRes> getMyMapListWithIsBookmarked(
             @CurrentUser User user,

--- a/src/main/java/com/ureca/uhyu/domain/mymap/controller/MyMapControllerDocs.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/controller/MyMapControllerDocs.java
@@ -341,68 +341,6 @@ public interface MyMapControllerDocs {
             ) @PathVariable String uuid
     );
 
-    @Operation(
-            summary = "UUID 기반 My Map 조회(비회원)",
-            description = """
-                    비회원이 UUID를 통해 공유된 My Map의 상세 정보를 조회합니다.
-                 
-                   **특징:**
-                    - 인증 불필요 (토큰 없이 접근 가능)
-                    - 회원용 조회와 동일한 데이터 반환
-                    - 공유 목적으로 사용됨
-                   
-                    **인증 불필요:** 별도 토큰 없이 접근 가능
-                   """
-    )
-    @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "My Map 조회 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = CommonResponse.class),
-                            examples = @ExampleObject(
-                                    name = "비회원 My Map 조회 성공 예시",
-                                    value = """
-                                           {
-                                              "statusCode": 0,
-                                              "message": "정상 처리 되었습니다.",
-                                              "data": {
-                                                "myMapListId": 1,
-                                                "title": "영화관 투어",
-                                                "markerColor": "RED",
-                                                "uuid": "550e8400-e29b-41d4-a716-446655440000",
-                                                "isMine": false,
-                                                "stores": [
-                                                  {
-                                                    "storeId": 1,
-                                                    "storeName": "CGV 동대문",
-                                                    "address": "서울특별시 중구 장충단로13길 20",
-                                                    "latitude": 37.5687346,
-                                                    "longitude": 127.0076665
-                                                  }
-                                                ]
-                                              }
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "My Map을 찾을 수 없음",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = CommonResponse.class)
-                    )
-            )
-    })
-    public CommonResponse<MyMapRes> getMyMapByUUIDWithGuest(
-            @Parameter(
-                    description = "My Map UUID",
-                    example = "550e8400-e29b-41d4-a716-446655440000"
-            ) @PathVariable String uuid
-    );
 
     @Operation(
             summary = "My Map 매장 등록 유무 조회",

--- a/src/main/java/com/ureca/uhyu/domain/mymap/service/MyMapService.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/service/MyMapService.java
@@ -105,17 +105,6 @@ public class MyMapService {
         return MyMapRes.from(myMapList, storeList, isMine);
     }
 
-    public MyMapRes findMyMapByUUIDWithGuest(String uuid) {
-        MyMapList myMapList = myMapListRepository.findByUuid(uuid).orElseThrow(() -> new GlobalException(ResultCode.MY_MAP_LIST_NOT_FOUND));
-        List<MyMap> myMaps = myMapRepository.findByMyMapList(myMapList);
-
-        List<MapRes> storeList = myMaps.stream()
-                .map(myMap -> MapRes.from(myMap.getStore()))
-                .toList();
-
-        return MyMapRes.from(myMapList, storeList, false);
-    }
-
     public BookmarkedMyMapRes findMyMapListWithIsBookmarked(User user, Long storeId) {
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new GlobalException(ResultCode.NOT_FOUND_STORE));

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationController.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationController.java
@@ -1,6 +1,5 @@
 package com.ureca.uhyu.domain.recommendation.controller;
 
-import com.ureca.uhyu.domain.recommendation.dto.response.GuestRecommendationRes;
 import com.ureca.uhyu.domain.recommendation.dto.response.RecommendationRes;
 import com.ureca.uhyu.domain.recommendation.service.RecommendationService;
 import com.ureca.uhyu.domain.user.entity.User;
@@ -32,11 +31,5 @@ public class RecommendationController implements RecommendationControllerDocs {
             ) @CurrentUser User user
     ) {
         return CommonResponse.success(recommendationService.getLatestTop3Recommendations(user));
-    }
-
-    @Override
-    @GetMapping("/guest/top3")
-    public CommonResponse<List<GuestRecommendationRes>> guestTop3Recommendation(){
-        return CommonResponse.success(recommendationService.getTop3PopularBrandsForGuest());
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationController.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationController.java
@@ -34,6 +34,7 @@ public class RecommendationController implements RecommendationControllerDocs {
         return CommonResponse.success(recommendationService.getLatestTop3Recommendations(user));
     }
 
+    @Override
     @GetMapping("/guest/top3")
     public CommonResponse<List<GuestRecommendationRes>> guestTop3Recommendation(){
         return CommonResponse.success(recommendationService.getTop3PopularBrandsForGuest());

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationController.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationController.java
@@ -1,5 +1,6 @@
 package com.ureca.uhyu.domain.recommendation.controller;
 
+import com.ureca.uhyu.domain.recommendation.dto.response.GuestRecommendationRes;
 import com.ureca.uhyu.domain.recommendation.dto.response.RecommendationRes;
 import com.ureca.uhyu.domain.recommendation.service.RecommendationService;
 import com.ureca.uhyu.domain.user.entity.User;
@@ -99,4 +100,7 @@ public class RecommendationController {
     }
 
     @GetMapping("/guest/top3")
+    public CommonResponse<List<GuestRecommendationRes>> guestTop3Recommendation(){
+        return CommonResponse.success(recommendationService.getTop3PopularBrandsForGuest());
+    }
 }

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationController.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationController.java
@@ -1,11 +1,10 @@
 package com.ureca.uhyu.domain.recommendation.controller;
 
-import com.ureca.uhyu.domain.recommendation.dto.RecommendationResponse;
+import com.ureca.uhyu.domain.recommendation.dto.response.RecommendationRes;
 import com.ureca.uhyu.domain.recommendation.service.RecommendationService;
 import com.ureca.uhyu.domain.user.entity.User;
 import com.ureca.uhyu.global.annotation.CurrentUser;
 import com.ureca.uhyu.global.response.CommonResponse;
-import com.ureca.uhyu.global.response.ResultCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -90,7 +89,7 @@ public class RecommendationController {
             )
     })
     @GetMapping
-    public CommonResponse<List<RecommendationResponse>> recommendation(
+    public CommonResponse<List<RecommendationRes>> recommendation(
             @Parameter(
                     description = "현재 로그인된 사용자 정보",
                     hidden = true
@@ -98,4 +97,6 @@ public class RecommendationController {
     ) {
         return CommonResponse.success(recommendationService.getLatestTop3Recommendations(user));
     }
+
+    @GetMapping("/guest/top3")
 }

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationController.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationController.java
@@ -6,14 +6,7 @@ import com.ureca.uhyu.domain.recommendation.service.RecommendationService;
 import com.ureca.uhyu.domain.user.entity.User;
 import com.ureca.uhyu.global.annotation.CurrentUser;
 import com.ureca.uhyu.global.response.CommonResponse;
-import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,69 +19,11 @@ import java.util.List;
 @RestController
 @RequestMapping("/recommendation")
 @RequiredArgsConstructor
-public class RecommendationController {
+public class RecommendationController implements RecommendationControllerDocs {
 
     private final RecommendationService recommendationService;
 
-    @Operation(
-            summary = "사용자 맞춤 추천 조회",
-            description = """
-                    사용자의 활동 패턴을 기반으로 맞춤형 브랜드를 추천합니다.
-                    
-                    **추천 기준:**
-                    - 최근 이용한 브랜드
-                    - 관심 있는 브랜드
-                    - 사용자 등급별 혜택
-                    - 지리적 위치
-                    
-                    **인증 필요:** JWT Bearer Token
-                    """,
-            security = @SecurityRequirement(name = "bearerAuth")
-    )
-    @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "추천 목록 조회 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = CommonResponse.class),
-                            examples = @ExampleObject(
-                                    name = "추천 목록 조회 성공 예시",
-                                    value = """
-                                            {
-                                              "statusCode": 0,
-                                              "message": "정상 처리 되었습니다.",
-                                              "data": [
-                                                {
-                                                  "brandId": 2,
-                                                  "brandName": "CGV",
-                                                  "rank": 1
-                                                },
-                                                {
-                                                  "brandId": 3,
-                                                  "brandName": "롯데시네마",
-                                                  "rank": 2
-                                                },
-                                                {
-                                                  "brandId": 4,
-                                                  "brandName": "메가박스",
-                                                  "rank": 3
-                                                }
-                                              ]
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "401",
-                    description = "인증 실패",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = CommonResponse.class)
-                    )
-            )
-    })
+    @Override
     @GetMapping
     public CommonResponse<List<RecommendationRes>> recommendation(
             @Parameter(

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationControllerDocs.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationControllerDocs.java
@@ -1,6 +1,5 @@
 package com.ureca.uhyu.domain.recommendation.controller;
 
-import com.ureca.uhyu.domain.recommendation.dto.response.GuestRecommendationRes;
 import com.ureca.uhyu.domain.recommendation.dto.response.RecommendationRes;
 import com.ureca.uhyu.domain.user.entity.User;
 import com.ureca.uhyu.global.annotation.CurrentUser;
@@ -82,52 +81,4 @@ public interface RecommendationControllerDocs {
                     description = "현재 로그인된 사용자 정보",
                     hidden = true
             ) @CurrentUser User user);
-
-    @Operation(
-            summary = "비로그인 사용자 인기 브랜드 Top3 조회",
-            description = """
-                    전체 사용자 방문 기록을 기반으로 가장 많이 이용된 브랜드 상위 3개를 반환합니다.
-                    
-                    **추천 기준:**
-                    - 모든 사용자의 History 데이터를 기반으로 방문 수가 많은 브랜드 순서로 정렬
-                    - 브랜드명, 로고 이미지 포함
-                    
-                    **인증 불필요:** 누구나 접근 가능
-                    """
-    )
-    @ApiResponse(
-            responseCode = "200",
-            description = "비로그인 추천 브랜드 조회 성공",
-            content = @Content(
-                    mediaType = "application/json",
-                    schema = @Schema(implementation = CommonResponse.class),
-                    examples = @ExampleObject(
-                            name = "비로그인 인기 브랜드 Top3 예시",
-                            value = """
-                                    {
-                                      "statusCode": 0,
-                                      "message": "정상 처리 되었습니다.",
-                                      "data": [
-                                        {
-                                          "brandId": 1,
-                                          "brandName": "스타벅스",
-                                          "logoImg": "starbucks.png"
-                                        },
-                                        {
-                                          "brandId": 2,
-                                          "brandName": "투썸플레이스",
-                                          "logoImg": "twosome.png"
-                                        },
-                                        {
-                                          "brandId": 3,
-                                          "brandName": "이디야",
-                                          "logoImg": "ediya.png"
-                                        }
-                                      ]
-                                    }
-                                    """
-                    )
-            )
-    )
-    CommonResponse<List<GuestRecommendationRes>> guestTop3Recommendation();
 }

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationControllerDocs.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationControllerDocs.java
@@ -1,0 +1,133 @@
+package com.ureca.uhyu.domain.recommendation.controller;
+
+import com.ureca.uhyu.domain.recommendation.dto.response.GuestRecommendationRes;
+import com.ureca.uhyu.domain.recommendation.dto.response.RecommendationRes;
+import com.ureca.uhyu.domain.user.entity.User;
+import com.ureca.uhyu.global.annotation.CurrentUser;
+import com.ureca.uhyu.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.util.List;
+
+public interface RecommendationControllerDocs {
+
+    @Operation(
+            summary = "사용자 맞춤 추천 조회",
+            description = """
+                    사용자의 활동 패턴을 기반으로 맞춤형 브랜드를 추천합니다.
+                    
+                    **추천 기준:**
+                    - 최근 이용한 브랜드
+                    - 관심 있는 브랜드
+                    - 사용자 등급별 혜택
+                    - 지리적 위치
+                    
+                    **인증 필요:** JWT Bearer Token
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "추천 목록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(
+                                    name = "추천 목록 조회 성공 예시",
+                                    value = """
+                                            {
+                                              "statusCode": 0,
+                                              "message": "정상 처리 되었습니다.",
+                                              "data": [
+                                                {
+                                                  "brandId": 2,
+                                                  "brandName": "CGV",
+                                                  "rank": 1
+                                                },
+                                                {
+                                                  "brandId": 3,
+                                                  "brandName": "롯데시네마",
+                                                  "rank": 2
+                                                },
+                                                {
+                                                  "brandId": 4,
+                                                  "brandName": "메가박스",
+                                                  "rank": 3
+                                                }
+                                              ]
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CommonResponse.class)
+                    )
+            )
+    })
+    CommonResponse<List<RecommendationRes>> recommendation(
+            @Parameter(
+                    description = "현재 로그인된 사용자 정보",
+                    hidden = true
+            ) @CurrentUser User user);
+
+    @Operation(
+            summary = "비로그인 사용자 인기 브랜드 Top3 조회",
+            description = """
+                    전체 사용자 방문 기록을 기반으로 가장 많이 이용된 브랜드 상위 3개를 반환합니다.
+                    
+                    **추천 기준:**
+                    - 모든 사용자의 History 데이터를 기반으로 방문 수가 많은 브랜드 순서로 정렬
+                    - 브랜드명, 로고 이미지 포함
+                    
+                    **인증 불필요:** 누구나 접근 가능
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "비로그인 추천 브랜드 조회 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = CommonResponse.class),
+                    examples = @ExampleObject(
+                            name = "비로그인 인기 브랜드 Top3 예시",
+                            value = """
+                                    {
+                                      "statusCode": 0,
+                                      "message": "정상 처리 되었습니다.",
+                                      "data": [
+                                        {
+                                          "brandId": 1,
+                                          "brandName": "스타벅스",
+                                          "logoImg": "starbucks.png"
+                                        },
+                                        {
+                                          "brandId": 2,
+                                          "brandName": "투썸플레이스",
+                                          "logoImg": "twosome.png"
+                                        },
+                                        {
+                                          "brandId": 3,
+                                          "brandName": "이디야",
+                                          "logoImg": "ediya.png"
+                                        }
+                                      ]
+                                    }
+                                    """
+                    )
+            )
+    )
+    CommonResponse<List<GuestRecommendationRes>> guestTop3Recommendation();
+}

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/dto/response/GuestRecommendationRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/dto/response/GuestRecommendationRes.java
@@ -1,0 +1,11 @@
+package com.ureca.uhyu.domain.recommendation.dto.response;
+
+public record GuestRecommendationRes (
+        Long brandId,
+        String brandName,
+        String logoImg
+){
+    public static GuestRecommendationRes from(Long brandId, String BrandName, String logoImg){
+        return new GuestRecommendationRes(brandId, BrandName, logoImg);
+    }
+}

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/dto/response/GuestRecommendationRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/dto/response/GuestRecommendationRes.java
@@ -5,7 +5,7 @@ public record GuestRecommendationRes (
         String brandName,
         String logoImg
 ){
-    public static GuestRecommendationRes from(Long brandId, String BrandName, String logoImg){
-        return new GuestRecommendationRes(brandId, BrandName, logoImg);
+    public static GuestRecommendationRes from(Long brandId, String brandName, String logoImg){
+        return new GuestRecommendationRes(brandId, brandName, logoImg);
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/dto/response/RecommendationRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/dto/response/RecommendationRes.java
@@ -1,14 +1,14 @@
-package com.ureca.uhyu.domain.recommendation.dto;
+package com.ureca.uhyu.domain.recommendation.dto.response;
 
 import com.ureca.uhyu.domain.recommendation.entity.Recommendation;
 
-public record RecommendationResponse(
+public record RecommendationRes(
         Long brandId,
         String brandName,
         Integer rank
 ){
-    public static RecommendationResponse from(Recommendation recommendation) {
-        return new RecommendationResponse(
+    public static RecommendationRes from(Recommendation recommendation) {
+        return new RecommendationRes(
                 recommendation.getBrand().getId(),
                 recommendation.getBrand().getBrandName(),
                 recommendation.getRank()

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/repository/RecommendationRepositoryCustom.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/repository/RecommendationRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.ureca.uhyu.domain.recommendation.repository;
 
 import com.ureca.uhyu.domain.admin.dto.response.StatisticsRecommendationRes;
+import com.ureca.uhyu.domain.brand.entity.Brand;
 import com.ureca.uhyu.domain.recommendation.entity.Recommendation;
 
 import java.util.List;
@@ -9,4 +10,6 @@ public interface RecommendationRepositoryCustom {
     List<Recommendation> findTop3ByUserOrderByCreatedAtDescRankAsc(Long userId);
 
     List<StatisticsRecommendationRes> findStatisticsRecommendationByCategory();
+
+    List<Brand> findTop3BrandByVisitCountFromHistory();
 }

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/repository/RecommendationRepositoryCustomImpl.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/repository/RecommendationRepositoryCustomImpl.java
@@ -4,10 +4,12 @@ import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.ureca.uhyu.domain.admin.dto.response.StatisticsRecommendationRes;
 import com.ureca.uhyu.domain.admin.dto.response.RecommendationsByBrand;
+import com.ureca.uhyu.domain.brand.entity.Brand;
 import com.ureca.uhyu.domain.brand.entity.QBrand;
 import com.ureca.uhyu.domain.brand.entity.QCategory;
 import com.ureca.uhyu.domain.recommendation.entity.QRecommendation;
 import com.ureca.uhyu.domain.recommendation.entity.Recommendation;
+import com.ureca.uhyu.domain.user.entity.QHistory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -103,5 +105,20 @@ public class RecommendationRepositoryCustomImpl implements RecommendationReposit
         }
 
         return result;
+    }
+
+    @Override
+    public List<Brand> findTop3BrandByVisitCountFromHistory() {
+        QHistory history = QHistory.history;
+        QBrand brand = QBrand.brand;
+
+        return queryFactory
+                .select(history.brand)
+                .from(history)
+                .where(history.brand.isNotNull())
+                .groupBy(history.brand)
+                .orderBy(history.count().desc())
+                .limit(3)
+                .fetch();
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/service/RecommendationService.java
@@ -1,5 +1,7 @@
 package com.ureca.uhyu.domain.recommendation.service;
 
+import com.ureca.uhyu.domain.brand.entity.Brand;
+import com.ureca.uhyu.domain.recommendation.dto.response.GuestRecommendationRes;
 import com.ureca.uhyu.domain.recommendation.dto.response.RecommendationRes;
 import com.ureca.uhyu.domain.recommendation.repository.RecommendationRepository;
 import com.ureca.uhyu.domain.user.entity.User;
@@ -32,6 +34,22 @@ public class RecommendationService {
                             r.getRank()
                     );
                 })
+                .toList();
+    }
+
+    public List<GuestRecommendationRes> getTop3PopularBrandsForGuest() {
+        List<Brand> brands = recommendationRepository.findTop3BrandByVisitCountFromHistory();
+
+        if (brands == null || brands.isEmpty()) {
+            throw new GlobalException((ResultCode.RECOMMENDATION_IS_NULL));
+        }
+        return recommendationRepository.findTop3BrandByVisitCountFromHistory()
+                .stream()
+                .map(brand -> GuestRecommendationRes.from(
+                        brand.getId(),
+                        brand.getBrandName(),
+                        brand.getLogoImage()
+                ))
                 .toList();
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/service/RecommendationService.java
@@ -1,7 +1,5 @@
 package com.ureca.uhyu.domain.recommendation.service;
 
-import com.ureca.uhyu.domain.brand.entity.Brand;
-import com.ureca.uhyu.domain.recommendation.dto.response.GuestRecommendationRes;
 import com.ureca.uhyu.domain.recommendation.dto.response.RecommendationRes;
 import com.ureca.uhyu.domain.recommendation.repository.RecommendationRepository;
 import com.ureca.uhyu.domain.user.entity.User;
@@ -34,21 +32,6 @@ public class RecommendationService {
                             r.getRank()
                     );
                 })
-                .toList();
-    }
-
-    public List<GuestRecommendationRes> getTop3PopularBrandsForGuest() {
-        List<Brand> brands = recommendationRepository.findTop3BrandByVisitCountFromHistory();
-
-        if (brands == null || brands.isEmpty()) {
-            throw new GlobalException((ResultCode.BRAND_ID_IS_NULL));
-        }
-        return brands.stream()
-                .map(brand -> GuestRecommendationRes.from(
-                        brand.getId(),
-                        brand.getBrandName(),
-                        brand.getLogoImage()
-                ))
                 .toList();
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/service/RecommendationService.java
@@ -1,7 +1,6 @@
 package com.ureca.uhyu.domain.recommendation.service;
 
-import com.ureca.uhyu.domain.recommendation.dto.RecommendationResponse;
-import com.ureca.uhyu.domain.recommendation.entity.Recommendation;
+import com.ureca.uhyu.domain.recommendation.dto.response.RecommendationRes;
 import com.ureca.uhyu.domain.recommendation.repository.RecommendationRepository;
 import com.ureca.uhyu.domain.user.entity.User;
 import com.ureca.uhyu.global.exception.GlobalException;
@@ -9,8 +8,6 @@ import com.ureca.uhyu.global.response.ResultCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
 
 @Service
@@ -19,7 +16,7 @@ public class RecommendationService {
 
     private final RecommendationRepository recommendationRepository;
 
-    public List<RecommendationResponse> getLatestTop3Recommendations(User user) {
+    public List<RecommendationRes> getLatestTop3Recommendations(User user) {
         Long userId = user.getId();
 
         // 가장 최근 추천 받은 브랜드들 중 top3 추천 브랜드 가져오기
@@ -29,7 +26,7 @@ public class RecommendationService {
                     if (r.getBrand() == null) {
                         throw new GlobalException((ResultCode.BRAND_ID_IS_NULL));
                     }
-                    return new RecommendationResponse(
+                    return new RecommendationRes(
                             r.getBrand().getId(),
                             r.getBrand().getBrandName(),
                             r.getRank()

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/service/RecommendationService.java
@@ -41,10 +41,9 @@ public class RecommendationService {
         List<Brand> brands = recommendationRepository.findTop3BrandByVisitCountFromHistory();
 
         if (brands == null || brands.isEmpty()) {
-            throw new GlobalException((ResultCode.RECOMMENDATION_IS_NULL));
+            throw new GlobalException((ResultCode.BRAND_ID_IS_NULL));
         }
-        return recommendationRepository.findTop3BrandByVisitCountFromHistory()
-                .stream()
+        return brands.stream()
                 .map(brand -> GuestRecommendationRes.from(
                         brand.getId(),
                         brand.getBrandName(),

--- a/src/main/java/com/ureca/uhyu/global/config/SecurityConfig.java
+++ b/src/main/java/com/ureca/uhyu/global/config/SecurityConfig.java
@@ -78,7 +78,7 @@ public class SecurityConfig {
                                 "/", "/login", "/oauth2/**",
                                 "/swagger-ui/**", "/v3/api-docs/**",
                                 "/brand-list/**",
-                                "/map/stores","/actuator/prometheus","/metrics", "/mymap/guest/**", "/recommendation/guest/**"
+                                "/map/stores","/actuator/prometheus","/metrics", "/mymap/guest/**", "/guest/**"
                         ).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/admin/**")).hasRole("ADMIN")
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()

--- a/src/main/java/com/ureca/uhyu/global/config/SecurityConfig.java
+++ b/src/main/java/com/ureca/uhyu/global/config/SecurityConfig.java
@@ -78,7 +78,7 @@ public class SecurityConfig {
                                 "/", "/login", "/oauth2/**",
                                 "/swagger-ui/**", "/v3/api-docs/**",
                                 "/brand-list/**",
-                                "/map/stores","/actuator/prometheus","/metrics"
+                                "/map/stores","/actuator/prometheus","/metrics", "/recommendation/guest/**"
                         ).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/admin/**")).hasRole("ADMIN")
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()

--- a/src/main/java/com/ureca/uhyu/global/response/ResultCode.java
+++ b/src/main/java/com/ureca/uhyu/global/response/ResultCode.java
@@ -63,6 +63,7 @@ public enum ResultCode {
      */
     BRAND_NOT_FOUND(HttpStatus.NOT_FOUND, 5001, "제휴처 정보를 찾을 수 없습니다."),
     NOT_FOUND_CATEGORY(HttpStatus.NOT_FOUND, 5002, "카테고리 정보를 찾을 수 없습니다."),
+    RECOMMENDATION_IS_NULL(HttpStatus.NOT_FOUND, 5003, "추천할 브랜드 정보가 없습니다"),
 
     /**
      * 6000번대 (어드민 관련)

--- a/src/main/java/com/ureca/uhyu/global/util/TokenCookieUtil.java
+++ b/src/main/java/com/ureca/uhyu/global/util/TokenCookieUtil.java
@@ -28,6 +28,7 @@ public final class TokenCookieUtil {
         expiredCookie.setSecure(true); // HTTPS 환경에서만 전달될 수 있도록
         expiredCookie.setPath("/");
         expiredCookie.setMaxAge(0); // 즉시 만료
+        expiredCookie.setDomain(".u-hyu.site/");
         response.addCookie(expiredCookie);
     }
 }

--- a/src/main/java/com/ureca/uhyu/global/util/TokenCookieUtil.java
+++ b/src/main/java/com/ureca/uhyu/global/util/TokenCookieUtil.java
@@ -28,7 +28,7 @@ public final class TokenCookieUtil {
         expiredCookie.setSecure(true); // HTTPS 환경에서만 전달될 수 있도록
         expiredCookie.setPath("/");
         expiredCookie.setMaxAge(0); // 즉시 만료
-        expiredCookie.setDomain(".u-hyu.site/");
+        expiredCookie.setDomain(".u-hyu.site");
         response.addCookie(expiredCookie);
     }
 }

--- a/src/test/java/com/ureca/uhyu/domain/mymap/service/MyMapServiceTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/mymap/service/MyMapServiceTest.java
@@ -4,6 +4,7 @@ import com.ureca.uhyu.domain.brand.entity.Benefit;
 import com.ureca.uhyu.domain.brand.entity.Brand;
 import com.ureca.uhyu.domain.brand.entity.Category;
 import com.ureca.uhyu.domain.brand.enums.StoreType;
+import com.ureca.uhyu.domain.guest.service.GuestService;
 import com.ureca.uhyu.domain.mymap.dto.request.CreateMyMapListReq;
 import com.ureca.uhyu.domain.mymap.dto.request.UpdateMyMapListReq;
 import com.ureca.uhyu.domain.mymap.dto.response.*;
@@ -65,6 +66,9 @@ class MyMapServiceTest {
 
     @InjectMocks
     private MyMapService myMapService;
+
+    @InjectMocks
+    private GuestService guestService;
 
     @DisplayName("mymap 목록 조회 - 성공")
     @Test
@@ -351,7 +355,7 @@ class MyMapServiceTest {
         when(myMapRepository.findByMyMapList(myMapList)).thenReturn(myMaps);
 
         // when
-        MyMapRes result = myMapService.findMyMapByUUIDWithGuest(uuid);
+        MyMapRes result = guestService.findMyMapByUUIDWithGuest(uuid);
 
         // then
         assertNotNull(result);

--- a/src/test/java/com/ureca/uhyu/domain/mymap/service/MyMapServiceTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/mymap/service/MyMapServiceTest.java
@@ -13,6 +13,7 @@ import com.ureca.uhyu.domain.mymap.entity.MyMapList;
 import com.ureca.uhyu.domain.mymap.enums.MarkerColor;
 import com.ureca.uhyu.domain.mymap.repository.MyMapListRepository;
 import com.ureca.uhyu.domain.mymap.repository.MyMapRepository;
+import com.ureca.uhyu.domain.recommendation.repository.RecommendationRepository;
 import com.ureca.uhyu.domain.store.entity.Store;
 import com.ureca.uhyu.domain.store.repository.StoreRepository;
 import com.ureca.uhyu.domain.user.entity.Bookmark;
@@ -22,6 +23,7 @@ import com.ureca.uhyu.domain.user.enums.Gender;
 import com.ureca.uhyu.domain.user.enums.Grade;
 import com.ureca.uhyu.domain.user.enums.Status;
 import com.ureca.uhyu.domain.user.enums.UserRole;
+import com.ureca.uhyu.domain.user.repository.UserRepository;
 import com.ureca.uhyu.domain.user.repository.bookmark.BookmarkListRepository;
 import com.ureca.uhyu.domain.user.repository.bookmark.BookmarkRepository;
 import com.ureca.uhyu.global.exception.GlobalException;
@@ -63,6 +65,9 @@ class MyMapServiceTest {
 
     @Mock
     private StoreRepository storeRepository;
+
+    @Mock
+    private RecommendationRepository recommendationRepository;
 
     @InjectMocks
     private MyMapService myMapService;

--- a/src/test/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationControllerTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationControllerTest.java
@@ -1,6 +1,6 @@
 package com.ureca.uhyu.domain.recommendation.controller;
 
-import com.ureca.uhyu.domain.recommendation.dto.RecommendationResponse;
+import com.ureca.uhyu.domain.recommendation.dto.response.RecommendationRes;
 import com.ureca.uhyu.domain.recommendation.service.RecommendationService;
 import com.ureca.uhyu.domain.user.entity.User;
 import org.junit.jupiter.api.BeforeEach;
@@ -55,10 +55,10 @@ class RecommendationControllerTest {
     @DisplayName("가장 최신 추천 결과 Top3 브랜드를 반환한다")
     void it_returns_top3_recommendations() throws Exception {
         // given
-        List<RecommendationResponse> mockResponse = List.of(
-                new RecommendationResponse(1L, "스타벅스", 1),
-                new RecommendationResponse(2L, "이디야", 2),
-                new RecommendationResponse(3L, "투썸플레이스", 3)
+        List<RecommendationRes> mockResponse = List.of(
+                new RecommendationRes(1L, "스타벅스", 1),
+                new RecommendationRes(2L, "이디야", 2),
+                new RecommendationRes(3L, "투썸플레이스", 3)
         );
 
         given(recommendationService.getLatestTop3Recommendations(any(User.class)))

--- a/src/test/java/com/ureca/uhyu/domain/recommendation/service/RecommendationServiceTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/recommendation/service/RecommendationServiceTest.java
@@ -1,0 +1,82 @@
+package com.ureca.uhyu.domain.recommendation.service;
+
+import com.ureca.uhyu.domain.brand.entity.Brand;
+import com.ureca.uhyu.domain.recommendation.dto.response.GuestRecommendationRes;
+import com.ureca.uhyu.domain.recommendation.repository.RecommendationRepository;
+import com.ureca.uhyu.global.exception.GlobalException;
+import com.ureca.uhyu.global.response.ResultCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RecommendationServiceTest {
+
+    @Mock
+    private RecommendationRepository recommendationRepository;
+
+    @InjectMocks
+    private RecommendationService recommendationService;
+
+    @DisplayName("비로그인 추천 - 인기 브랜드 1~3개 반환")
+    @Test
+    void getTop3PopularBrandsForGuest_success() {
+        // given
+        Brand brand1 = createBrand("CGV", "cgv.png");
+        setId(brand1, 1L);
+        Brand brand2 = createBrand("롯데시네마", "lotte.png");
+        setId(brand2, 2L);
+
+        List<Brand> brands = List.of(brand1, brand2);
+        when(recommendationRepository.findTop3BrandByVisitCountFromHistory()).thenReturn(brands);
+
+        // when
+        List<GuestRecommendationRes> result = recommendationService.getTop3PopularBrandsForGuest();
+
+        // then
+        assertEquals(2, result.size());
+        assertEquals("CGV", result.get(0).brandName());
+        assertEquals("롯데시네마", result.get(1).brandName());
+    }
+
+    @DisplayName("비로그인 추천 - 인기 브랜드 없음")
+    @Test
+    void getTop3PopularBrandsForGuest_empty() {
+        // given
+        when(recommendationRepository.findTop3BrandByVisitCountFromHistory()).thenReturn(Collections.emptyList());
+
+        // when & then
+        GlobalException exception = assertThrows(GlobalException.class, () -> {
+            recommendationService.getTop3PopularBrandsForGuest();
+        });
+
+        assertEquals(ResultCode.RECOMMENDATION_IS_NULL, exception.getResultCode());
+    }
+
+    private Brand createBrand(String name, String logoImage) {
+        return Brand.builder()
+                .brandName(name)
+                .logoImage(logoImage)
+                .build();
+    }
+
+    private void setId(Object target, Long idValue) {
+        try {
+            Field idField = target.getClass().getSuperclass().getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(target, idValue);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/ureca/uhyu/domain/recommendation/service/RecommendationServiceTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/recommendation/service/RecommendationServiceTest.java
@@ -1,7 +1,8 @@
 package com.ureca.uhyu.domain.recommendation.service;
 
 import com.ureca.uhyu.domain.brand.entity.Brand;
-import com.ureca.uhyu.domain.recommendation.dto.response.GuestRecommendationRes;
+import com.ureca.uhyu.domain.guest.dto.response.GuestRecommendationRes;
+import com.ureca.uhyu.domain.guest.service.GuestService;
 import com.ureca.uhyu.domain.recommendation.repository.RecommendationRepository;
 import com.ureca.uhyu.global.exception.GlobalException;
 import com.ureca.uhyu.global.response.ResultCode;
@@ -26,7 +27,7 @@ class RecommendationServiceTest {
     private RecommendationRepository recommendationRepository;
 
     @InjectMocks
-    private RecommendationService recommendationService;
+    private GuestService guestService;
 
     @DisplayName("비로그인 추천 - 인기 브랜드 1~3개 반환")
     @Test
@@ -41,7 +42,7 @@ class RecommendationServiceTest {
         when(recommendationRepository.findTop3BrandByVisitCountFromHistory()).thenReturn(brands);
 
         // when
-        List<GuestRecommendationRes> result = recommendationService.getTop3PopularBrandsForGuest();
+        List<GuestRecommendationRes> result = guestService.getTop3PopularBrandsForGuest();
 
         // then
         assertEquals(2, result.size());
@@ -57,7 +58,7 @@ class RecommendationServiceTest {
 
         // when & then
         GlobalException exception = assertThrows(GlobalException.class, () -> {
-            recommendationService.getTop3PopularBrandsForGuest();
+            guestService.getTop3PopularBrandsForGuest();
         });
 
         assertEquals(ResultCode.RECOMMENDATION_IS_NULL, exception.getResultCode());


### PR DESCRIPTION
## 📌 작업 개요
- 비로그인 사용자 대상 인기 브랜드 Top3를 제공하는 API 기능 구현
- 전체 사용자 History 테이블 기반으로 브랜드별 방문 횟수를 집계하여 상위 3개 브랜드를 반환
- Swagger 문서화 분리(RecommendationControllerDocs)로 컨트롤러 클래스 정리
- 비로그인 사용자 요청 기능 관련하여 guest 도메인으로 분리하였습니다.
- 로그아웃 배포 도메인 추가

## ✨ 기타 참고 사항
- 추천 결과가 존재하지 않을 경우 GlobalException(ResultCode.RECOMMENDATION_NOT_FOUND)을 반환
- 3개 미만이 조회될 경우, 3개 미만 반환
- 프론트에서 로그인 유저에게 추천 제공 대신 비로그인 유저에게 제공

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **신규 기능**
  * 비회원 사용자를 위한 게스트 전용 API 엔드포인트(마이맵 조회, 인기 브랜드 추천) 추가
  * 비회원 인기 브랜드 추천 응답 DTO 및 서비스 로직 추가

* **버그 수정**
  * 추천 브랜드가 없을 때 적절한 예외 및 에러 코드 반환

* **리팩터링**
  * API 문서용 인터페이스 분리 및 컨트롤러 내 Swagger/OpenAPI 어노테이션 이동
  * 추천 관련 DTO, 서비스, 테스트 코드 네이밍 및 패키지 구조 정리

* **테스트**
  * 게스트 추천 서비스 및 컨트롤러 테스트 추가 및 기존 테스트 코드 수정

* **기타**
  * "/guest/**" 경로에 대한 비로그인 접근 허용
  * 불필요해진 마이맵 게스트 조회 기능 기존 위치에서 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->