### PR TITLE
[REFACTOR][UHYU-298] 관리자 즐겨찾기 + My Map 통계 기능 쿼리 수정 및 최적화

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/admin/service/AdminService.java
+++ b/src/main/java/com/ureca/uhyu/domain/admin/service/AdminService.java
@@ -28,57 +28,7 @@ public class AdminService {
     private final HistoryRepository historyRepository;
 
     public List<StatisticsBookmarkRes> findStatisticsBookmarkByCategoryAndBrand() {
-        Set<UserBrandPair> userBrandSaves = bookmarkRepository.findUserBrandSaves();
-        Map<Long, Tuple> brandCategoryMap = bookmarkRepository.findBrandToCategoryMap();
-
-        log.debug("Retrieved {} user-brand pairs and {} brand-category mappings",
-                userBrandSaves.size(), brandCategoryMap.size());
-
-        // 브랜드별 저장 수
-        Map<Long, Integer> brandSaveCounts = userBrandSaves.stream()
-                .collect(Collectors.groupingBy(
-                        UserBrandPair::brandId,
-                        Collectors.collectingAndThen(Collectors.counting(), Long::intValue)
-                ));
-        return aggregateBookmarksByCategory(brandSaveCounts, brandCategoryMap);
-    }
-
-    private List<StatisticsBookmarkRes> aggregateBookmarksByCategory(Map<Long, Integer> brandSaveCounts, Map<Long, Tuple> brandCategoryMap) {
-        // 카테고리별 DTO 조립
-        Map<Long, StatisticsBookmarkRes> categoryMap = new LinkedHashMap<>();
-
-        for (Map.Entry<Long, Integer> entry : brandSaveCounts.entrySet()) {
-            Long brandId = entry.getKey();
-            int count = entry.getValue();
-
-            Tuple t = brandCategoryMap.get(brandId);
-            if (t == null) continue;
-
-            Long categoryId = t.get(CATEGORY_ID_INDEX, Long.class);
-            String categoryName = t.get(CATEGORY_NAME_INDEX, String.class);
-            String brandName = t.get(BRAND_NAME_INDEX, String.class);
-
-            if (categoryId == null || categoryName == null || brandName == null) {
-                log.warn("Invalid data in tuple for brandId: {}", brandId);
-                continue;
-            }
-
-            BookmarksByBrand brandRes = BookmarksByBrand.of(brandName, count);
-
-            categoryMap.compute(categoryId, (key, existing) -> {
-                if (existing == null) {
-                    List<BookmarksByBrand> brandList = new ArrayList<>();
-                    brandList.add(brandRes);
-                    return StatisticsBookmarkRes.of(categoryId, categoryName, count, brandList);
-                } else {
-                    existing.bookmarksByBrandList().add(brandRes);
-                    int newSum = existing.sumStatisticsBookmarksByCategory() + count;
-                    return StatisticsBookmarkRes.of(categoryId, categoryName, newSum, existing.bookmarksByBrandList());
-                }
-            });
-        }
-
-        return new ArrayList<>(categoryMap.values());
+        return bookmarkRepository.findStatisticsBookmarkByCategoryAndBrand();
     }
 
     public List<StatisticsFilterRes> findStatisticsFilterByCategory() {

--- a/src/main/java/com/ureca/uhyu/domain/admin/service/AdminService.java
+++ b/src/main/java/com/ureca/uhyu/domain/admin/service/AdminService.java
@@ -1,6 +1,5 @@
 package com.ureca.uhyu.domain.admin.service;
 
-import com.querydsl.core.Tuple;
 import com.ureca.uhyu.domain.admin.dto.response.*;
 import com.ureca.uhyu.domain.user.repository.actionLogs.ActionLogsRepository;
 import com.ureca.uhyu.domain.recommendation.repository.RecommendationRepository;
@@ -12,15 +11,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AdminService {
-    private static final int CATEGORY_ID_INDEX = 1;
-    private static final int CATEGORY_NAME_INDEX = 2;
-    private static final int BRAND_NAME_INDEX = 3;
 
     private final BookmarkRepository bookmarkRepository;
     private final ActionLogsRepository actionLogsRepository;

--- a/src/main/java/com/ureca/uhyu/domain/user/repository/bookmark/BookmarkRepositoryCustom.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/repository/bookmark/BookmarkRepositoryCustom.java
@@ -1,13 +1,10 @@
 package com.ureca.uhyu.domain.user.repository.bookmark;
 
 
-import com.querydsl.core.Tuple;
-import com.ureca.uhyu.domain.admin.dto.response.UserBrandPair;
+import com.ureca.uhyu.domain.admin.dto.response.StatisticsBookmarkRes;
 
-import java.util.Map;
-import java.util.Set;
+import java.util.List;
 
 public interface BookmarkRepositoryCustom {
-    Set<UserBrandPair> findUserBrandSaves();
-    Map<Long, Tuple> findBrandToCategoryMap();
+    public List<StatisticsBookmarkRes> findStatisticsBookmarkByCategoryAndBrand();
 }

--- a/src/main/java/com/ureca/uhyu/domain/user/repository/bookmark/BookmarkRepositoryCustomImpl.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/repository/bookmark/BookmarkRepositoryCustomImpl.java
@@ -2,7 +2,10 @@ package com.ureca.uhyu.domain.user.repository.bookmark;
 
 
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ureca.uhyu.domain.admin.dto.response.BookmarksByBrand;
+import com.ureca.uhyu.domain.admin.dto.response.StatisticsBookmarkRes;
 import com.ureca.uhyu.domain.admin.dto.response.UserBrandPair;
 import com.ureca.uhyu.domain.brand.entity.QBrand;
 import com.ureca.uhyu.domain.brand.entity.QCategory;
@@ -24,65 +27,92 @@ public class BookmarkRepositoryCustomImpl implements BookmarkRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Set<UserBrandPair> findUserBrandSaves() {
+    public List<StatisticsBookmarkRes> findStatisticsBookmarkByCategoryAndBrand() {
         QBookmark bookmark = QBookmark.bookmark;
         QBookmarkList bookmarkList = QBookmarkList.bookmarkList;
         QMyMap myMap = QMyMap.myMap;
         QMyMapList myMapList = QMyMapList.myMapList;
         QStore store = QStore.store;
+        QBrand brand = QBrand.brand;
+        QCategory category = QCategory.category;
 
-        List<Tuple> bookmarkTuples = queryFactory
-                .select(bookmarkList.user.id, store.brand.id)
+        // bookmark 쿼리
+        List<UserBrandPair> bookmarkPairs = queryFactory
+                .select(Projections.constructor(UserBrandPair.class,
+                        bookmarkList.user.id,
+                        store.brand.id))
                 .from(bookmark)
                 .join(bookmark.bookmarkList, bookmarkList)
                 .join(bookmark.store, store)
                 .fetch();
 
-        List<Tuple> myMapTuples = queryFactory
-                .select(myMapList.user.id, store.brand.id)
+        // myMap 쿼리
+        List<UserBrandPair> myMapPairs = queryFactory
+                .select(Projections.constructor(UserBrandPair.class,
+                        myMapList.user.id,
+                        store.brand.id))
                 .from(myMap)
                 .join(myMap.myMapList, myMapList)
                 .join(myMap.store, store)
                 .fetch();
 
-        Set<UserBrandPair> savedPairs = new HashSet<>();
-        bookmarkTuples.forEach(t -> {
-            Long userId = t.get(0, Long.class);
-            Long brandId = t.get(1, Long.class);
-            if (userId != null && brandId != null) {
-                savedPairs.add(new UserBrandPair(userId, brandId));
-            }
-        });
-        myMapTuples.forEach(t -> {
-            Long userId = t.get(0, Long.class);
-            Long brandId = t.get(1, Long.class);
-            if (userId != null && brandId != null) {
-                savedPairs.add(new UserBrandPair(userId, brandId));
-            }
-        });
+        // 중복 제거된 user-brand 쌍 수집
+        Set<UserBrandPair> allPairs = new HashSet<>();
+        allPairs.addAll(bookmarkPairs);
+        allPairs.addAll(myMapPairs);
 
-        return savedPairs;
-    }
+        // 브랜드별 저장 수 카운트
+        Map<Long, Integer> brandSaveCounts = allPairs.stream()
+                .collect(Collectors.groupingBy(
+                        UserBrandPair::brandId,
+                        Collectors.collectingAndThen(Collectors.counting(), Long::intValue)
+                ));
 
-    @Override
-    public Map<Long, Tuple> findBrandToCategoryMap() {
-        QBrand brand = QBrand.brand;
-        QCategory category = QCategory.category;
-
-        return queryFactory
+        // 브랜드 → 카테고리 정보 조회
+        Map<Long, Tuple> brandInfoMap = queryFactory
                 .select(
                         brand.id,
+                        brand.brandName,
                         category.id,
-                        category.categoryName,
-                        brand.brandName
+                        category.categoryName
                 )
                 .from(brand)
                 .join(brand.category, category)
+                .where(brand.id.in(brandSaveCounts.keySet()))
                 .fetch()
                 .stream()
                 .collect(Collectors.toMap(
-                        t -> t.get(0, Long.class), // brandId
-                        t -> t                     // Tuple(brandId, categoryId, categoryName, brandName)
+                        t -> t.get(0, Long.class),
+                        t -> t
                 ));
+
+        // 카테고리 기준으로 그룹핑 및 DTO 조립
+        Map<Long, StatisticsBookmarkRes> resultMap = new LinkedHashMap<>();
+
+        for (Map.Entry<Long, Integer> entry : brandSaveCounts.entrySet()) {
+            Long brandId = entry.getKey();
+            Integer count = entry.getValue();
+
+            Tuple brandInfo = brandInfoMap.get(brandId);
+            if (brandInfo == null) continue;
+
+            String brandName = brandInfo.get(1, String.class);
+            Long categoryId = brandInfo.get(2, Long.class);
+            String categoryName = brandInfo.get(3, String.class);
+
+            BookmarksByBrand bookmarksByBrand = BookmarksByBrand.of(brandName, count);
+
+            resultMap.compute(categoryId, (key, existing) -> {
+                if (existing == null) {
+                    return StatisticsBookmarkRes.of(categoryId, categoryName, count, new ArrayList<>(List.of(bookmarksByBrand)));
+                } else {
+                    existing.bookmarksByBrandList().add(bookmarksByBrand);
+                    int newSum = existing.sumStatisticsBookmarksByCategory() + count;
+                    return StatisticsBookmarkRes.of(categoryId, categoryName, newSum, existing.bookmarksByBrandList());
+                }
+            });
+        }
+
+        return new ArrayList<>(resultMap.values());
     }
 }

--- a/src/test/java/com/ureca/uhyu/domain/recommendation/service/RecommendationServiceTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/recommendation/service/RecommendationServiceTest.java
@@ -61,7 +61,7 @@ class RecommendationServiceTest {
             guestService.getTop3PopularBrandsForGuest();
         });
 
-        assertEquals(ResultCode.RECOMMENDATION_IS_NULL, exception.getResultCode());
+        assertEquals(ResultCode.NOT_FOUND_RECOMMENDATION_FOR_USER, exception.getResultCode());
     }
 
     private Brand createBrand(String name, String logoImage) {


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 쿼리 결과를 Tuple과 맵으로 가져와서 서비스 로직에서 dto 매핑하던 로직을 repository에서 바로 매핑하도록 쿼리 로직 변경
- 해당 로직 관련 테스트 코드 수정

## ✨ 기타 참고 사항
<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 카테고리 및 브랜드별 북마크 통계 조회 기능이 단일 리포지토리 호출로 단순화되어, 더 일관되고 신뢰할 수 있는 통계 데이터를 제공합니다.

* **테스트**
  * 통계 조회 관련 테스트가 간소화되어, 데이터 응답 구조에 맞는 검증으로 변경되었습니다.
  * 추천 서비스 테스트에서 인기 브랜드 조회 실패 시 반환되는 에러 코드 검증이 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->