### PR TITLE
[UHYU-303] fix: 로그아웃 도메인 에러 수정

### DIFF
--- a/src/main/java/com/ureca/uhyu/global/config/SecurityConfig.java
+++ b/src/main/java/com/ureca/uhyu/global/config/SecurityConfig.java
@@ -78,7 +78,7 @@ public class SecurityConfig {
                                 "/", "/login", "/oauth2/**",
                                 "/swagger-ui/**", "/v3/api-docs/**",
                                 "/brand-list/**",
-                                "/map/stores","/actuator/prometheus","/metrics", "/mymap/guest/**", "/guest/**"
+                                "/map/stores","/actuator/prometheus","/metrics", "/guest/**"
                         ).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/admin/**")).hasRole("ADMIN")
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()

--- a/src/main/java/com/ureca/uhyu/global/util/TokenCookieUtil.java
+++ b/src/main/java/com/ureca/uhyu/global/util/TokenCookieUtil.java
@@ -28,7 +28,7 @@ public final class TokenCookieUtil {
         expiredCookie.setSecure(true); // HTTPS 환경에서만 전달될 수 있도록
         expiredCookie.setPath("/");
         expiredCookie.setMaxAge(0); // 즉시 만료
-        expiredCookie.setDomain(".u-hyu.site");
+        expiredCookie.setDomain("u-hyu.site");
         response.addCookie(expiredCookie);
     }
 }


### PR DESCRIPTION
## 📌 작업 개요
- 도메인 에러 수정

## ✨ 기타 참고 사항
<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 

## ✅ PR 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [ ] 로컬 서버에서 정상 동작을 확인했어요.
- [ ] 불필요한 코드/주석 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * "/mymap/guest/**" 경로가 더 이상 인증 없이 접근할 수 있는 공개 엔드포인트 목록에 포함되지 않습니다.
  * 만료된 액세스 토큰 쿠키의 도메인 속성이 ".u-hyu.site"에서 "u-hyu.site"로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->