### PR TITLE
[FIX][UHYU-329] MyMapList 엔티티 수정

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/mymap/entity/MyMapList.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/entity/MyMapList.java
@@ -6,6 +6,8 @@ import com.ureca.uhyu.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.List;
+
 @Entity
 @Table(name = "my_map_list")
 @Getter
@@ -23,6 +25,9 @@ public class MyMapList extends BaseEntity {
 
     @Column(name = "uuid", nullable = false, unique = true)
     private String uuid;
+
+    @OneToMany(mappedBy = "myMapList", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MyMap> myMaps;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/resources/db/changelog/2025/07/31-01-changelog.xml
+++ b/src/main/resources/db/changelog/2025/07/31-01-changelog.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.29.xsd"
+        objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+    <changeSet id="1753969503171-1" author="c">
+        <addUniqueConstraint columnNames="uuid" constraintName="uc_my_map_list_uuid" tableName="my_map_list"/>
+    </changeSet>
+    <changeSet id="1753969503171-4" author="c">
+        <dropColumn columnName="deleted" tableName="brands"/>
+
+        <dropUniqueConstraint constraintName="uc_action_logs_user" tableName="action_logs"/>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- MyMapList에 My Map들이 남아있을 시 삭제가 안되는 오류를 해결하기 위해 엔티티 수정
- MyMap과의 cascade 옵션 설정

## ✨ 기타 참고 사항
<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 여러 MyMap 엔티티를 MyMapList에서 관리할 수 있는 기능이 추가되었습니다.

* **버그 수정**
  * brands 테이블에서 deleted 컬럼이 제거되었습니다.
  * action_logs 테이블의 기존 고유 제약 조건이 삭제되었습니다.

* **기타**
  * my_map_list 테이블의 uuid 컬럼에 고유 제약 조건이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->