### PR TITLE
[FEAT][UHYU-328]: 지도 즐겨찾기 매장 조회 로직 수정 및 Grade별 Benefit 로직 리팩토링

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/brand/entity/Brand.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/entity/Brand.java
@@ -2,10 +2,10 @@ package com.ureca.uhyu.domain.brand.entity;
 
 import com.ureca.uhyu.domain.brand.enums.StoreType;
 import com.ureca.uhyu.domain.store.entity.Store;
+import com.ureca.uhyu.domain.user.enums.Grade;
 import com.ureca.uhyu.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.Where;
 
 import java.util.List;
 
@@ -49,5 +49,18 @@ public class Brand extends BaseEntity {
         this.usageMethod = usageMethod;
         this.usageLimit = usageLimit;
         this.storeType = storeType;
+    }
+
+    public String getBenefitDescriptionByGradeOrDefault(Grade grade) {
+        return this.benefits.stream()
+                .filter(b -> b.getGrade() == grade)
+                .findFirst()
+                .orElseGet(() ->
+                        this.benefits.stream()
+                                .filter(b -> b.getGrade() == Grade.GOOD)
+                                .findFirst()
+                                .get()
+                )
+                .getDescription();
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/brand/entity/Brand.java
+++ b/src/main/java/com/ureca/uhyu/domain/brand/entity/Brand.java
@@ -4,6 +4,8 @@ import com.ureca.uhyu.domain.brand.enums.StoreType;
 import com.ureca.uhyu.domain.store.entity.Store;
 import com.ureca.uhyu.domain.user.enums.Grade;
 import com.ureca.uhyu.global.entity.BaseEntity;
+import com.ureca.uhyu.global.exception.GlobalException;
+import com.ureca.uhyu.global.response.ResultCode;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -55,12 +57,10 @@ public class Brand extends BaseEntity {
         return this.benefits.stream()
                 .filter(b -> b.getGrade() == grade)
                 .findFirst()
-                .orElseGet(() ->
-                        this.benefits.stream()
-                                .filter(b -> b.getGrade() == Grade.GOOD)
-                                .findFirst()
-                                .get()
-                )
-                .getDescription();
+                .or(() -> this.benefits.stream()
+                        .filter(b -> b.getGrade() == Grade.GOOD)
+                        .findFirst())
+                .map(Benefit::getDescription)
+                .orElseThrow(() -> new GlobalException(ResultCode.GRADE_GOOD_NOT_FOUND));
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/map/controller/MapController.java
+++ b/src/main/java/com/ureca/uhyu/domain/map/controller/MapController.java
@@ -34,6 +34,13 @@ public class MapController implements MapControllerDocs{
         return CommonResponse.success(ResultCode.SUCCESS, mapService.getFilteredStores(lat, lon, radius, category, brand));
     }
 
+    @GetMapping("/stores/bookmark")
+    public CommonResponse<List<MapRes>> GetBookmarkedStores(
+            @CurrentUser User user
+    ){
+        return CommonResponse.success(ResultCode.SUCCESS, mapService.getBookmarkedStores(user));
+    }
+
     @GetMapping("/detail/stores/{storeId}")
     public CommonResponse<StoreDetailRes> getStoreDetail(
             @PathVariable Long storeId,

--- a/src/main/java/com/ureca/uhyu/domain/map/dto/response/MapRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/map/dto/response/MapRes.java
@@ -3,7 +3,10 @@ package com.ureca.uhyu.domain.map.dto.response;
 import com.ureca.uhyu.domain.brand.entity.Brand;
 import com.ureca.uhyu.domain.brand.entity.Category;
 import com.ureca.uhyu.domain.store.entity.Store;
+import com.ureca.uhyu.domain.user.entity.User;
+import com.ureca.uhyu.domain.user.enums.Grade;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
 
 @Schema(description = "지도 제휴매장 정보 응답 DTO")
 public record MapRes(
@@ -34,12 +37,16 @@ public record MapRes(
         @Schema(description = "경도")
         Double longitude
 ) {
-        public static MapRes from(Store store) {
+        public static MapRes from(Store store){
+                return from(store,null);
+        }
+
+        public static MapRes from(Store store, @Nullable User user) {
                 Brand brand = store.getBrand();
                 Category category = brand.getCategory();
 
-                // TODO : 헤택(Benefit) 회원 등급별로 표시되는건지 확인 후 로직 수정
-                String benefit = null;
+                Grade grade = (user != null) ? user.getGrade() : Grade.GOOD;
+                String benefit = brand.getBenefitDescriptionByGradeOrDefault(grade);
 
                 return new MapRes(
                         store.getId(),

--- a/src/main/java/com/ureca/uhyu/domain/map/service/MapService.java
+++ b/src/main/java/com/ureca/uhyu/domain/map/service/MapService.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 public interface MapService {
     List<MapRes> getFilteredStores(Double lat, Double lon, Double radius, String category, String brand);
+    List<MapRes> getBookmarkedStores(User user);
     StoreDetailRes getStoreDetail(Long storeId, User user);
     MapBookmarkRes toggleBookmark(User user, Long storeId);
     List<MapRes> findRecommendedStores(Double lat, Double lon, Double radius, User user);

--- a/src/main/java/com/ureca/uhyu/domain/map/service/MapServiceImpl.java
+++ b/src/main/java/com/ureca/uhyu/domain/map/service/MapServiceImpl.java
@@ -1,6 +1,5 @@
 package com.ureca.uhyu.domain.map.service;
 
-import com.ureca.uhyu.domain.brand.entity.Benefit;
 import com.ureca.uhyu.domain.brand.entity.Brand;
 import com.ureca.uhyu.domain.map.dto.response.MapBookmarkRes;
 import com.ureca.uhyu.domain.map.dto.response.MapRes;
@@ -43,6 +42,19 @@ public class MapServiceImpl implements MapService {
     }
 
     @Override
+    public List<MapRes> getBookmarkedStores(User user) {
+        BookmarkList bookmarkList = bookmarkListRepository.findByUser(user)
+                .orElseThrow(() -> new GlobalException(ResultCode.BOOKMARK_LIST_NOT_FOUND));
+
+        List<Bookmark> bookmarks = bookmarkRepository.findByBookmarkList(bookmarkList);
+
+        return bookmarks.stream()
+                .map(Bookmark::getStore)
+                .map(MapRes::from)
+                .toList();
+    }
+
+    @Override
     public StoreDetailRes getStoreDetail(Long storeId, User user) {
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new GlobalException(ResultCode.NOT_FOUND_STORE));
@@ -50,27 +62,13 @@ public class MapServiceImpl implements MapService {
         Brand brand = store.getBrand();
         Grade userGrade = user.getGrade();
 
-        // 등급별 혜택 조회
-        Optional<Benefit> matchingBenefit = brand.getBenefits().stream()
-                .filter(b -> b.getGrade() == userGrade)
-                .findFirst();
+        String benefitDescription = brand.getBenefitDescriptionByGradeOrDefault(userGrade);
 
-        Benefit selected = matchingBenefit.orElseGet(() ->
-                brand.getBenefits().stream()
-                        .filter(b -> b.getGrade() == Grade.GOOD)
-                        .findFirst()
-                        .orElse(null)
+        StoreDetailRes.BenefitDetail benefitDetail = new StoreDetailRes.BenefitDetail(
+                userGrade.name(),
+                benefitDescription
         );
 
-        StoreDetailRes.BenefitDetail benefitDetail = null;
-        if (selected != null) {
-            benefitDetail = new StoreDetailRes.BenefitDetail(
-                    selected.getGrade().name(),
-                    selected.getDescription()
-            );
-        }
-
-        // 🔽 즐겨찾기 관련 정보 조회
         boolean isFavorite = bookmarkRepository.existsByBookmarkListUserAndStore(user, store);
         int favoriteCount = bookmarkRepository.countByStore(store);
 

--- a/src/main/java/com/ureca/uhyu/domain/map/service/MapServiceImpl.java
+++ b/src/main/java/com/ureca/uhyu/domain/map/service/MapServiceImpl.java
@@ -50,7 +50,7 @@ public class MapServiceImpl implements MapService {
 
         return bookmarks.stream()
                 .map(Bookmark::getStore)
-                .map(MapRes::from)
+                .map(store -> MapRes.from(store, user))
                 .toList();
     }
 
@@ -127,7 +127,7 @@ public class MapServiceImpl implements MapService {
         List<Store> stores = storeRepositoryCustom.findStoresByBrandAndRadius(lat, lon, radius, brandIds);
 
         return stores.stream()
-                .map(MapRes::from)
+                .map(store -> MapRes.from(store,user))
                 .toList();
     }
 }

--- a/src/main/java/com/ureca/uhyu/global/response/ResultCode.java
+++ b/src/main/java/com/ureca/uhyu/global/response/ResultCode.java
@@ -64,6 +64,7 @@ public enum ResultCode {
     BRAND_NOT_FOUND(HttpStatus.NOT_FOUND, 5001, "제휴처 정보를 찾을 수 없습니다."),
     NOT_FOUND_CATEGORY(HttpStatus.NOT_FOUND, 5002, "카테고리 정보를 찾을 수 없습니다."),
     RECOMMENDATION_IS_NULL(HttpStatus.NOT_FOUND, 5003, "추천할 브랜드 정보가 없습니다"),
+    GRADE_GOOD_NOT_FOUND(HttpStatus.NOT_FOUND,5004,"우수 회원의 혜택 정보가 없습니다."),
 
     /**
      * 6000번대 (어드민 관련)


### PR DESCRIPTION
## 📌 작업 개요

- 지도 내에서 즐겨찾기한 매장 목록을 반환하는 API 개발
- MapRes의 from 메서드에서 기존에 TODO로 등록한 "등급별 헤택 반환" 로직 추가
- 이를 위해 기존에 User 객체가 인자로 넘어오지 않게 사용되던 MapRes.from을 사용하기 위한 from 메서드 오버라이딩
- 등급별 혜택 저장을 위한 getBenefitDescriptionByGradeOrDefault() 메서드 추가

## ✨ 기타 참고 사항

- 직업 개요에 작성했습니다. 

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 북마크한 매장을 조회하는 새로운 GET 엔드포인트가 추가되었습니다.
  * 사용자의 등급에 따라 맞춤형 혜택 설명이 매장 정보에 표시됩니다.

* **버그 수정**
  * 매장 상세 조회 시 등급별 혜택 설명이 더 정확하게 표시되도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->