### PR TITLE
feat: Prometheus + Grafana + PostgreSQL Exporter 세팅 완료

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -6,7 +6,7 @@ services:
     container_name: prometheus
     restart: unless-stopped
     ports:
-      - "9090:9090"
+      - "9090:9090" 
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
       - ./data/prometheus:/prometheus
@@ -37,7 +37,7 @@ services:
       - .env
     environment:
       - DISABLE_SETTINGS_METRICS=true
-      - DATA_SOURCE_NAME=postgresql://${SPRING_DATASOURCE_USERNAME}:${SPRING_DATASOURCE_PASSWORD}@${EXPORTER_DB_HOST}?sslmode=disable
+      - DATA_SOURCE_NAME=postgresql://${SPRING_DATASOURCE_USERNAME}:${SPRING_DATASOURCE_PASSWORD}@${EXPORTER_DB_HOST}?sslmode=require&connect_timeout=5
     networks:
       - monitor-net
 

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -5,8 +5,8 @@ scrape_configs:
   - job_name: 'spring'
     metrics_path: '/actuator/prometheus'
     static_configs:
-      - targets: ['43.203.223.179:8080']
+      - targets: ['api.u-hyu.site']
 
   - job_name: 'pgexporter'
     static_configs:
-      - targets: ['43.203.223.179:9187']
+      - targets: ['postgres-exporter:9187']


### PR DESCRIPTION
## 📌 작업 개요

-  배포환경에 맞는 Prometheus + Grafana + PostgreSQL Exporter 모니터링 구축 완료

- 추가된 docker-compose.monitoring.yml과 prometheus.yml은 Spring 서버에서 사용되는 코드는 아닙니다.
- 두 코드를 가지고 모니터링 서버 ec2에서 지금 U-Hyu-be 레포지토리의 코드를 가져와서 사용하기 위해서 해당 레포지토리에 추가합니다.
- Spring 서버, DB(RDS), 모니터링 서버 구조에 대해서 설명이 필요한 부분이 있으면 설명드리겠습니다.

## ✨ 기타 참고 사항

### Spring 서버 모니터링
<img width="1920" height="936" alt="image" src="https://github.com/user-attachments/assets/05116a94-490f-462c-b3f8-734bbf2111af" />


### Postgresql 모니터링
<img width="1919" height="936" alt="image" src="https://github.com/user-attachments/assets/099b4ae3-159a-4448-900e-06828987062c" />

 

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * Prometheus 및 postgres-exporter 서비스의 데이터 소스 연결 설정이 개선되어 SSL이 필수로 적용되고 연결 타임아웃(5초)이 추가되었습니다.

* **기타**
  * Prometheus 스크레이프 대상이 IP 주소에서 읽기 쉬운 호스트명으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->