### PR TITLE
[FIX][UHYU-345] : 로그인 로직 프론트와 맞추기 위한 수정

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/auth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/ureca/uhyu/domain/auth/handler/OAuth2SuccessHandler.java
@@ -83,7 +83,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         // 사용자 역할에 따른 리다이렉트 경로 결정
         String finalRedirectUrl = userRole== UserRole.TMP_USER
                 ? frontBaseUrl + "/user/extra-info"
-                : frontBaseUrl;
+                : frontBaseUrl + "/auth/success";
 
         log.debug("Final redirect URL: '{}'", finalRedirectUrl);
         return finalRedirectUrl;

--- a/src/main/java/com/ureca/uhyu/domain/user/controller/UserController.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/controller/UserController.java
@@ -30,7 +30,7 @@ public class UserController implements UserControllerDocs {
     private final UserService userService;
     private final TokenService tokenService;
 
-    @PostMapping("/extra-info")
+    @PostMapping("/onboarding")
     public CommonResponse<ResultCode> onboarding(
             @Valid @RequestBody UserOnboardingReq request,
             HttpServletResponse response,

--- a/src/main/java/com/ureca/uhyu/global/config/PermitAllURI.java
+++ b/src/main/java/com/ureca/uhyu/global/config/PermitAllURI.java
@@ -13,6 +13,7 @@ public enum PermitAllURI {
     DOCS("/v3/api-docs"),
     ROOT("/"),
     BRAND_LIST("/brand-list"),
+    INTEREST_BRAND_LIST("/brand-list/interest"),
     PROMETHEUS("/actuator/prometheus"),
     PGEXPORTER("/metrics"),
     MYMAP_GUEST("/mymap/guest");

--- a/src/main/java/com/ureca/uhyu/global/config/SecurityConfig.java
+++ b/src/main/java/com/ureca/uhyu/global/config/SecurityConfig.java
@@ -77,7 +77,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/", "/login", "/oauth2/**",
                                 "/swagger-ui/**", "/v3/api-docs/**",
-                                "/brand-list/**",
+                                "/brand-list/**","/brand-list/interest",
                                 "/map/stores","/actuator/prometheus","/metrics", "/guest/**"
                         ).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/admin/**")).hasRole("ADMIN")


### PR DESCRIPTION
## 📌 작업 개요

- 배포환경 오류 발생으로 프론트 요청에 따른 온보딩 및 로그인 로직 수정

## ✨ 기타 참고 사항

- 

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * "/brand-list/interest" 경로가 인증 없이 접근 가능한 공개 경로에 추가되었습니다.

* **변경 사항**
  * OAuth2 인증 성공 후 TMP_USER가 아닌 사용자는 이제 "/auth/success"로 리다이렉트됩니다.
  * 사용자 온보딩 API 엔드포인트가 "/extra-info"에서 "/onboarding"으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->