### PR TITLE
[FIX][UHYU-335] 추천 브랜드 기반 근처 매장 조회 로직 수정 및 문제 해결

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/map/controller/MapController.java
+++ b/src/main/java/com/ureca/uhyu/domain/map/controller/MapController.java
@@ -62,9 +62,8 @@ public class MapController implements MapControllerDocs{
     public CommonResponse<List<MapRes>> getRecommendedStores(
             @RequestParam Double lat,
             @RequestParam Double lon,
-            @RequestParam Double radius,
             @CurrentUser User user
     ) {
-        return CommonResponse.success(mapService.findRecommendedStores(lat, lon, radius, user));
+        return CommonResponse.success(mapService.findRecommendedStores(lat, lon, user));
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/map/controller/MapControllerDocs.java
+++ b/src/main/java/com/ureca/uhyu/domain/map/controller/MapControllerDocs.java
@@ -246,7 +246,6 @@ public interface MapControllerDocs {
     public CommonResponse<List<MapRes>> getRecommendedStores(
             @RequestParam Double lat,
             @RequestParam Double lon,
-            @RequestParam Double radius,
             @CurrentUser User user
     );
 }

--- a/src/main/java/com/ureca/uhyu/domain/map/dto/response/MapRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/map/dto/response/MapRes.java
@@ -60,4 +60,20 @@ public record MapRes(
                         store.getGeom().getX()
                 );
         }
+
+        public static MapRes from(Brand brand) {
+                String benefit = brand.getBenefitDescriptionByGradeOrDefault(Grade.GOOD);
+
+                return new MapRes(
+                        null,                                    //브랜드 정보를 가져오므로 storeId는 없음
+                        brand.getBrandName(),                          //매장 이름 대신 브랜드 명
+                        brand.getCategory().getCategoryName(),
+                        null,                               //브랜드 정보를 가져오므로 위치 정보는 없음
+                        benefit,
+                        brand.getLogoImage(),
+                        brand.getBrandName(),
+                        null,                                   //좌표값 없으므로 null
+                        null                                            //좌표값 없으므로 null
+                );
+        }
 }

--- a/src/main/java/com/ureca/uhyu/domain/map/service/MapService.java
+++ b/src/main/java/com/ureca/uhyu/domain/map/service/MapService.java
@@ -13,5 +13,5 @@ public interface MapService {
     List<MapRes> getBookmarkedStores(User user);
     StoreDetailRes getStoreDetail(Long storeId, User user);
     MapBookmarkRes toggleBookmark(User user, Long storeId);
-    List<MapRes> findRecommendedStores(Double lat, Double lon, Double radius, User user);
+    List<MapRes> findRecommendedStores(Double lat, Double lon, User user);
 }

--- a/src/main/java/com/ureca/uhyu/domain/store/repository/StoreRepositoryCustom.java
+++ b/src/main/java/com/ureca/uhyu/domain/store/repository/StoreRepositoryCustom.java
@@ -6,5 +6,5 @@ import java.util.List;
 public interface StoreRepositoryCustom {
     List<Store> findStoresByFilters(Double lon, Double lat, Double radius, String categoryName, String brandName);
 
-    List<Store> findStoresByBrandAndRadius(Double lat, Double lon, Double radius, List<Long> brandIds);
+    List<Store> findNearestStores(Double lat, Double lon, List<Long> brandIds);
 }

--- a/src/main/java/com/ureca/uhyu/domain/store/repository/StoreRepositoryCustomImpl.java
+++ b/src/main/java/com/ureca/uhyu/domain/store/repository/StoreRepositoryCustomImpl.java
@@ -82,6 +82,9 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
         for (Long brandId : brandIds) {
             Store nearest = queryFactory
                     .selectFrom(store)
+                    .leftJoin(store.brand, brand).fetchJoin()
+                    .leftJoin(brand.category, category).fetchJoin()
+                    .leftJoin(brand.benefits, benefit).fetchJoin()
                     .where(store.brand.id.eq(brandId))
                     .orderBy(distanceExpr.asc())
                     .limit(1)

--- a/src/main/java/com/ureca/uhyu/domain/store/repository/StoreRepositoryCustomImpl.java
+++ b/src/main/java/com/ureca/uhyu/domain/store/repository/StoreRepositoryCustomImpl.java
@@ -73,7 +73,7 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
         }
 
         NumberTemplate<Double> distanceExpr = Expressions.numberTemplate(Double.class,
-                "ST_Distance(ST_Transform({0}, 3857), ST_Transform(ST_SetSRID(ST_MakePoint({1}, {2}), 4326), 3857))",
+                "ST_DistanceSphere({0}, ST_SetSRID(ST_MakePoint({1}, {2}), 4326))",
                 store.geom, lon, lat
         );
 

--- a/src/test/java/com/ureca/uhyu/domain/map/service/MapServiceImplTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/map/service/MapServiceImplTest.java
@@ -167,7 +167,6 @@ class MapServiceImplTest {
         setId(user, 1L);
         double lat = 37.5665;
         double lon = 126.9780;
-        double radius = 5.0;
 
         Brand brand1 = createBrand("브랜드1", "logo1.png");
         Brand brand2 = createBrand("브랜드2", "logo2.png");
@@ -210,7 +209,6 @@ class MapServiceImplTest {
         setId(user, 1L);
         double lat = 37.0;
         double lon = 127.0;
-        double radius = 3.0;
 
         Recommendation invalidRec = Recommendation.builder()
                 .userId(user.getId())
@@ -339,7 +337,7 @@ class MapServiceImplTest {
 
             StoreDetailRes res = mapService.getStoreDetail(1L, user);
 
-            assertThat(res.benefits().grade()).isEqualTo("GOOD");
+            assertThat(res.benefits().grade()).isEqualTo("VIP");
             assertThat(res.benefits().benefitText()).isEqualTo("1+1 혜택");
         }
 

--- a/src/test/java/com/ureca/uhyu/domain/map/service/MapServiceImplTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/map/service/MapServiceImplTest.java
@@ -3,6 +3,7 @@ package com.ureca.uhyu.domain.map.service;
 import com.ureca.uhyu.domain.brand.entity.Benefit;
 import com.ureca.uhyu.domain.brand.entity.Brand;
 import com.ureca.uhyu.domain.brand.entity.Category;
+import com.ureca.uhyu.domain.brand.enums.BenefitType;
 import com.ureca.uhyu.domain.brand.enums.StoreType;
 import com.ureca.uhyu.domain.map.dto.response.MapBookmarkRes;
 import com.ureca.uhyu.domain.map.dto.response.MapRes;
@@ -71,10 +72,29 @@ class MapServiceImplTest {
             .categoryName("카페")
             .build();
 
+    private final Benefit benefit1 = Benefit.builder()
+            .description("50원 할인")
+            .grade(Grade.GOOD)
+            .benefitType(BenefitType.DISCOUNT)
+            .build();
+
+    private final Benefit benefit2 = Benefit.builder()
+            .description("100원 할인")
+            .grade(Grade.VIP)
+            .benefitType(BenefitType.DISCOUNT)
+            .build();
+
+    private final Benefit benefit3 = Benefit.builder()
+            .description("150원 할인")
+            .grade(Grade.VVIP)
+            .benefitType(BenefitType.DISCOUNT)
+            .build();
+
     private final Brand brand = Brand.builder()
             .brandName("이디야")
             .category(category)
             .logoImage("logo.jpg")
+            .benefits(List.of(benefit1, benefit2, benefit3))
             .usageLimit("1일 1회")
             .usageMethod("매장 제시")
             .build();
@@ -112,11 +132,6 @@ class MapServiceImplTest {
                 .build();
         setId(category, 1L);
 
-        Benefit benefit = Benefit.builder()
-                .description("혜택1")
-                .build();
-        setId(benefit, 2L);
-
         Brand brand = Brand.builder()
                 .category(category)
                 .brandName(name)
@@ -124,7 +139,7 @@ class MapServiceImplTest {
                 .usageMethod("모바일 바코드 제시")
                 .usageLimit("1일 1회")
                 .storeType(StoreType.OFFLINE)
-                .benefits(List.of(benefit))
+                .benefits(List.of(benefit1, benefit2, benefit3))
                 .build();
         return brand;
     }
@@ -342,16 +357,17 @@ class MapServiceImplTest {
         }
 
         @Test
-        void shouldReturnNullIfNoBenefitExists() {
+        void shouldThrowExceptionIfNoBenefitExists() {
+            // given
             User user = mock(User.class);
             when(user.getGrade()).thenReturn(Grade.VIP);
 
-            brand.setBenefits(List.of());
+            brand.setBenefits(List.of()); // 빈 리스트 설정
             when(storeRepository.findById(1L)).thenReturn(Optional.of(store));
+            when(user.getGrade()).thenReturn(Grade.VIP);
 
-            StoreDetailRes res = mapService.getStoreDetail(1L, user);
-
-            assertThat(res.benefits()).isNull();
+            // when & then
+            assertThrows(GlobalException.class, () -> mapService.getStoreDetail(1L, user));
         }
 
         @Test

--- a/src/test/java/com/ureca/uhyu/domain/map/service/MapServiceImplTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/map/service/MapServiceImplTest.java
@@ -187,11 +187,11 @@ class MapServiceImplTest {
         // mock
         when(recommendationRepository.findTop3ByUserOrderByCreatedAtDescRankAsc(user.getId()))
                 .thenReturn(recommendations);
-        when(storeRepositoryCustom.findStoresByBrandAndRadius(lat, lon, radius, List.of(10L, 11L)))
+        when(storeRepositoryCustom.findNearestStores(lat, lon, List.of(10L, 11L)))
                 .thenReturn(stores);
 
         // when
-        List<MapRes> result = mapService.findRecommendedStores(lat, lon, radius, user);
+        List<MapRes> result = mapService.findRecommendedStores(lat, lon, user);
 
         // then
         assertEquals(2, result.size());
@@ -199,7 +199,7 @@ class MapServiceImplTest {
         assertEquals("스토어B", result.get(1).storeName());
 
         verify(recommendationRepository).findTop3ByUserOrderByCreatedAtDescRankAsc(user.getId());
-        verify(storeRepositoryCustom).findStoresByBrandAndRadius(lat, lon, radius, List.of(10L, 11L));
+        verify(storeRepositoryCustom).findNearestStores(lat, lon, List.of(10L, 11L));
     }
 
     @DisplayName("근처 추천 매장 목록 조회 - 브랜드가 null일 경우 예외 발생")
@@ -224,7 +224,7 @@ class MapServiceImplTest {
 
         // when & then
         GlobalException ex = assertThrows(GlobalException.class, () ->
-                mapService.findRecommendedStores(lat, lon, radius, user)
+                mapService.findRecommendedStores(lat, lon, user)
         );
 
         assertEquals(ResultCode.BRAND_ID_IS_NULL, ex.getResultCode());


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 추천 받은 브랜드가 store가 없는 ONLINE 타입의 브랜드가 있는 경우, 추천을 받았는지 알 수 없는 현상이 존재.
- 또한, store가 존재하는 브랜드를 추천 받아도 추천 매장의 갯수 제한을 두지 않아, 심한 경우 같은 브랜드의 80여개의 매장이 추천되기도 함.
- 해당 현상을 고치고자 추천 매장 조회 로직 및 쿼리를 변경하였음. (기존 : 사용자 위치 반경 5km 이내의 추천 브랜드의 매장 조회 / 수정 : 사용자 위치로부터 추천 받은 브랜드의 가장 가까운 매장 1개씩 출력(거리 제한 없음), ONLINE 타입의 브랜드인 경우 매장 정보 없이 브랜드 정보만 출력)
- 해당 로직 변경으로 인한 단위 테스트 코드 일부 수정

## ✨ 기타 참고 사항
<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 브랜드 정보를 기반으로 위치 정보 없이 추천 매장 목록에 온라인 브랜드가 표시됩니다.

* **버그 수정**
  * 추천 매장 조회 시 반경(radius) 입력값이 더 이상 필요하지 않습니다.

* **리팩터링**
  * 추천 매장 조회 로직이 온라인 브랜드와 오프라인 매장을 구분하여 처리하도록 개선되었습니다.
  * 각 브랜드별로 가장 가까운 오프라인 매장만 추천 목록에 포함됩니다.

* **테스트**
  * 변경된 추천 매장 조회 방식과 예외 상황에 맞춰 테스트 코드가 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->