### PR TITLE
[FIX][UHYU-340] : user/onboarding NTE에러 해결

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/auth/filter/TmpUserRedirectFilter.java
+++ b/src/main/java/com/ureca/uhyu/domain/auth/filter/TmpUserRedirectFilter.java
@@ -18,8 +18,8 @@ import java.util.Set;
 public class TmpUserRedirectFilter extends OncePerRequestFilter {
 
     private static final Set<String> ALLOWED_PATHS = Set.of(
-            "/user/extra-info",
-            "/user/check-email"
+            "/user/check-email",
+            "/user/onboarding"
     );
 
     @Override

--- a/src/main/java/com/ureca/uhyu/domain/auth/filter/TmpUserRedirectFilter.java
+++ b/src/main/java/com/ureca/uhyu/domain/auth/filter/TmpUserRedirectFilter.java
@@ -19,7 +19,8 @@ public class TmpUserRedirectFilter extends OncePerRequestFilter {
 
     private static final Set<String> ALLOWED_PATHS = Set.of(
             "/user/check-email",
-            "/user/onboarding"
+            "/user/onboarding",
+            "/user/extra-info"
     );
 
     @Override

--- a/src/main/java/com/ureca/uhyu/global/config/PermitAllURI.java
+++ b/src/main/java/com/ureca/uhyu/global/config/PermitAllURI.java
@@ -16,8 +16,7 @@ public enum PermitAllURI {
     INTEREST_BRAND_LIST("/brand-list/interest"),
     PROMETHEUS("/actuator/prometheus"),
     PGEXPORTER("/metrics"),
-    MYMAP_GUEST("/mymap/guest"),
-    ONBOARDING("/user/onboarding");
+    MYMAP_GUEST("/mymap/guest");
 
     private final String uri;
 


### PR DESCRIPTION
## 📌 작업 개요

- /user/onboarding은 TMP_USER의 상태에서 쏘는 API인데, @CurrentUser를 사용하기 위해 필터는 타지만, 요청은 허용되도록 수정 

## ✨ 기타 참고 사항

- 

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 임시 사용자("ROLE_TMP_USER")가 접근할 수 있는 경로가 "/user/extra-info"에서 "/user/onboarding" 및 "/user/check-email"로 변경되었습니다.

* **기타 변경**
  * 일부 내부 접근 허용 경로 목록이 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->