### PR TITLE
[FIX][UHYU-340] 추천 브랜드 싫어요 선택 시 brandId -> storeId 받도록 수정

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationControllerDocs.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationControllerDocs.java
@@ -148,7 +148,7 @@ public interface RecommendationControllerDocs {
                                     name = "브랜드 제외 요청 예시",
                                     value = """
                                             {
-                                              "brandId": 42
+                                              "storeId": 42
                                             }
                                             """
                             )

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/dto/request/ExcludeBrandRequest.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/dto/request/ExcludeBrandRequest.java
@@ -10,9 +10,9 @@ public record ExcludeBrandRequest(
                 example = "2"
         )
         @NotNull(message = "한 개의 브랜드 id가 선택되어야 합니다.")
-        Long brandId
+        Long storeId
 ) {
-    public static ExcludeBrandRequest from(Long brandId) {
-        return new ExcludeBrandRequest(brandId);
+    public static ExcludeBrandRequest from(Long storeId) {
+        return new ExcludeBrandRequest(storeId);
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/dto/request/ExcludeBrandRequest.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/dto/request/ExcludeBrandRequest.java
@@ -9,7 +9,7 @@ public record ExcludeBrandRequest(
                 description = "싫어요 누른 브랜드 id",
                 example = "2"
         )
-        @NotNull(message = "한 개의 브랜드 id가 선택되어야 합니다.")
+        @NotNull(message = "한 개의 매장 id가 선택되어야 합니다.")
         Long storeId
 ) {
     public static ExcludeBrandRequest from(Long storeId) {

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/service/RecommendationBaseDataService.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/service/RecommendationBaseDataService.java
@@ -7,6 +7,8 @@ import com.ureca.uhyu.domain.recommendation.dto.request.ExcludeBrandRequest;
 import com.ureca.uhyu.domain.recommendation.entity.RecommendationBaseData;
 import com.ureca.uhyu.domain.recommendation.enums.DataType;
 import com.ureca.uhyu.domain.recommendation.repository.RecommendationBaseDataRepository;
+import com.ureca.uhyu.domain.store.entity.Store;
+import com.ureca.uhyu.domain.store.repository.StoreRepository;
 import com.ureca.uhyu.domain.user.dto.response.SaveUserInfoRes;
 import com.ureca.uhyu.domain.user.entity.User;
 import com.ureca.uhyu.domain.user.repository.UserRepository;
@@ -20,24 +22,23 @@ import org.springframework.stereotype.Service;
 @Service
 public class RecommendationBaseDataService {
 
-    private final UserRepository userRepository;
-    private final BrandRepository brandRepository;
+    private final StoreRepository storeRepository;
     private final RecommendationBaseDataRepository recommendationBaseDataRepository;
     private final FastApiRecommendationClient fastApiRecommendationClient;
 
     @Transactional
     public SaveUserInfoRes excludeBrand(User user, ExcludeBrandRequest request) {
 
-        Brand brand = brandRepository.findById(request.brandId())
-                .orElseThrow(() -> new GlobalException(ResultCode.BRAND_NOT_FOUND));
+        Store store = storeRepository.findById(request.storeId())
+                .orElseThrow(() -> new GlobalException(ResultCode.STORE_NOT_FOUND));
 
         // 이미 EXCLUDE로 등록된 경우 중복 저장 방지
-        boolean exists = recommendationBaseDataRepository.existsByUserAndBrandAndDataType(user, brand, DataType.EXCLUDE);
+        boolean exists = recommendationBaseDataRepository.existsByUserAndBrandAndDataType(user, store.getBrand(), DataType.EXCLUDE);
 
         if (!exists) {
             RecommendationBaseData data = RecommendationBaseData.builder()
                     .user(user)
-                    .brand(brand)
+                    .brand(store.getBrand())
                     .dataType(DataType.EXCLUDE)
                     .build();
             recommendationBaseDataRepository.save(data);


### PR DESCRIPTION
## 📌 작업 개요
- 프론트에서 추천 받은 브랜드에 대해 brandId를 요청했는데, storeId 로 변경 후, service에서 store를 기반으로 brand 객체 찾도록 수정

## ✨ 기타 참고 사항
- 

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 추천 제외 요청 시 브랜드 ID 대신 매장 ID를 사용하도록 수정되었습니다.
  * 매장 정보를 기반으로 추천 제외가 처리되며, 관련 오류 메시지도 매장 기준으로 변경되었습니다.
  * API 문서 내 예시 요청 바디가 브랜드 ID에서 매장 ID로 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->