### PR TITLE
[FIX][UHYU-371] 관리자용 브랜드 목록 조회 api 응답 dto에 brand id 값 추가

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/admin/dto/response/AdminBrandRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/admin/dto/response/AdminBrandRes.java
@@ -7,6 +7,7 @@ import com.ureca.uhyu.domain.brand.enums.StoreType;
 import java.util.List;
 
 public record AdminBrandRes(
+        Long brandId,
         String brandName,
         String brandImg,
         List<BenefitDto> data,
@@ -18,6 +19,7 @@ public record AdminBrandRes(
     public static AdminBrandRes from(Brand brand
     ) {
         return new AdminBrandRes(
+                brand.getId(),
                 brand.getBrandName(),
                 brand.getLogoImage(),
                 brand.getBenefits().stream().map(BenefitDto::from).toList(),


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 브랜드 수정, 삭제 시 id 값이 필요한데 목록 조회에서 id값이 빠져있어 응답 dto에 brandId 추가

## ✨ 기타 참고 사항
<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 

## ✅ PR 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [ ] 로컬 서버에서 정상 동작을 확인했어요.
- [ ] 불필요한 코드/주석 삭제했어요.
