### PR TITLE
[CHORE][UHYU-374]  MapRes에서 brandId를 반환하도록 수정

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/map/dto/response/MapRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/map/dto/response/MapRes.java
@@ -31,6 +31,9 @@ public record MapRes(
         @Schema(description = "브랜드 이름")
         String brandName,
 
+        @Schema(description = "브랜드 ID")
+        Long brandId,
+
         @Schema(description = "위도")
         Double latitude,
 
@@ -55,7 +58,8 @@ public record MapRes(
                         store.getAddrDetail(),
                         benefit,
                         brand.getLogoImage(),
-                        store.getBrand().getBrandName(),
+                        brand.getBrandName(),
+                        brand.getId(),
                         store.getGeom().getY(),
                         store.getGeom().getX()
                 );
@@ -72,6 +76,7 @@ public record MapRes(
                         benefit,
                         brand.getLogoImage(),
                         brand.getBrandName(),
+                        brand.getId(),
                         null,                                   //좌표값 없으므로 null
                         null                                            //좌표값 없으므로 null
                 );


### PR DESCRIPTION
## 📌 작업 개요

- 온라인 혜택을 추천하는 경우 기존에 MapRes에서 brandId가 반환되지 않아서 storeId로 재추천을 요청해야하는데, 온라인 혜택은 storeId가 없는 문제가 발생하여서 brandId를 반환하도록 수정

## ✨ 기타 참고 사항

- 

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 지도 응답 데이터에 브랜드 ID 정보가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->