### PR TITLE
[FIX][UHYU-340] 추천 브랜드 싫어요 선택 시 storeId -> brandId 받도록 수정

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationControllerDocs.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/controller/RecommendationControllerDocs.java
@@ -148,7 +148,7 @@ public interface RecommendationControllerDocs {
                                     name = "브랜드 제외 요청 예시",
                                     value = """
                                             {
-                                              "storeId": 42
+                                              "brandId": 2
                                             }
                                             """
                             )

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/dto/request/ExcludeBrandRequest.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/dto/request/ExcludeBrandRequest.java
@@ -9,10 +9,10 @@ public record ExcludeBrandRequest(
                 description = "싫어요 누른 브랜드 id",
                 example = "2"
         )
-        @NotNull(message = "한 개의 매장 id가 선택되어야 합니다.")
-        Long storeId
+        @NotNull(message = "한 개의 브랜드 id가 선택되어야 합니다.")
+        Long brandId
 ) {
-    public static ExcludeBrandRequest from(Long storeId) {
-        return new ExcludeBrandRequest(storeId);
+    public static ExcludeBrandRequest from(Long brandId) {
+        return new ExcludeBrandRequest(brandId);
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/recommendation/service/RecommendationBaseDataService.java
+++ b/src/main/java/com/ureca/uhyu/domain/recommendation/service/RecommendationBaseDataService.java
@@ -22,23 +22,24 @@ import org.springframework.stereotype.Service;
 @Service
 public class RecommendationBaseDataService {
 
-    private final StoreRepository storeRepository;
+    private final BrandRepository brandRepository;
+    private final UserRepository userRepository;
     private final RecommendationBaseDataRepository recommendationBaseDataRepository;
     private final FastApiRecommendationClient fastApiRecommendationClient;
 
     @Transactional
     public SaveUserInfoRes excludeBrand(User user, ExcludeBrandRequest request) {
 
-        Store store = storeRepository.findById(request.storeId())
-                .orElseThrow(() -> new GlobalException(ResultCode.STORE_NOT_FOUND));
+        Brand brand = brandRepository.findById(request.brandId())
+                .orElseThrow(() -> new GlobalException(ResultCode.BRAND_NOT_FOUND));
 
         // 이미 EXCLUDE로 등록된 경우 중복 저장 방지
-        boolean exists = recommendationBaseDataRepository.existsByUserAndBrandAndDataType(user, store.getBrand(), DataType.EXCLUDE);
+        boolean exists = recommendationBaseDataRepository.existsByUserAndBrandAndDataType(user, brand, DataType.EXCLUDE);
 
         if (!exists) {
             RecommendationBaseData data = RecommendationBaseData.builder()
                     .user(user)
-                    .brand(store.getBrand())
+                    .brand(brand)
                     .dataType(DataType.EXCLUDE)
                     .build();
             recommendationBaseDataRepository.save(data);


### PR DESCRIPTION
## 📌 작업 개요
- 프론트에서 추천 받은 브랜드에 대해 다시 brandId로 요청하도록 수정

## ✨ 기타 참고 사항
<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * "추천 제외 브랜드 등록" API 문서의 예시 요청 본문에서 키를 "storeId"에서 "brandId"로 수정하고 예시 값을 2로 변경했습니다.

* **버그 수정**
  * 브랜드 제외 요청 시 storeId가 아닌 brandId를 사용하도록 요청 필드 및 검증 메시지를 수정했습니다.
  * 브랜드 제외 처리 로직에서 Store가 아닌 Brand를 직접 조회하여 처리하도록 변경했습니다.
  * 데이터가 없을 경우 발생하는 예외를 브랜드 기준으로 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->