### PR TITLE
[REFACTOR][UHYU-398] 이벤트 리스너 @TransactionalEventListener로 변경

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/admin/service/AdminService.java
+++ b/src/main/java/com/ureca/uhyu/domain/admin/service/AdminService.java
@@ -3,6 +3,7 @@ package com.ureca.uhyu.domain.admin.service;
 import com.querydsl.core.Tuple;
 import com.ureca.uhyu.domain.admin.dto.StatisticsDto;
 import com.ureca.uhyu.domain.admin.dto.response.*;
+import com.ureca.uhyu.domain.admin.entity.Statistics;
 import com.ureca.uhyu.domain.admin.enums.StatisticsType;
 import com.ureca.uhyu.domain.admin.repository.StatisticsRepository;
 import com.ureca.uhyu.domain.mymap.repository.MyMapRepository;
@@ -13,6 +14,8 @@ import com.ureca.uhyu.domain.user.repository.history.HistoryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -211,5 +214,22 @@ public class AdminService {
         log.debug("전체 통계 쿼리 실행 시간: " + elapsedMs + " ms");
 
         return StatisticsTotalRes.of(totalBookmarkMyMap, totalFiltering, totalMembershipUsage);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveStatistics(Statistics statistics) {
+        statisticsRepository.save(statistics);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void deleteStatisticsMyMapType(Long userId, Long storeId, Long myMapListId, StatisticsType statisticsType) {
+        statisticsRepository
+                .deleteByUserIdAndStoreIdAndMyMapListIdAndStatisticsType(userId, storeId, myMapListId, statisticsType);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void deleteStatisticsBookmarkType(Long userId, Long storeId, StatisticsType statisticsType) {
+        statisticsRepository
+                .deleteByUserIdAndStoreIdAndStatisticsType(userId, storeId, statisticsType);
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/map/event/BookmarkEventListener.java
+++ b/src/main/java/com/ureca/uhyu/domain/map/event/BookmarkEventListener.java
@@ -2,18 +2,21 @@ package com.ureca.uhyu.domain.map.event;
 
 import com.ureca.uhyu.domain.admin.entity.Statistics;
 import com.ureca.uhyu.domain.admin.enums.StatisticsType;
-import com.ureca.uhyu.domain.admin.repository.StatisticsRepository;
+import com.ureca.uhyu.domain.admin.service.AdminService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.event.EventListener;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class BookmarkEventListener {
 
-    private final StatisticsRepository statisticsRepository;
+    private final AdminService adminService;
 
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleBookmarkToggled(BookmarkToggledEvent event) {
         if (event.getAction() == BookmarkToggledEvent.Action.ADD) {
             Statistics statistics = Statistics.builder()
@@ -25,10 +28,10 @@ public class BookmarkEventListener {
                     .categoryName(event.getCategoryName())
                     .statisticsType(StatisticsType.BOOKMARK)
                     .build();
-            statisticsRepository.save(statistics);
+            adminService.saveStatistics(statistics);
 
         } else if (event.getAction() == BookmarkToggledEvent.Action.REMOVE) {
-            statisticsRepository.deleteByUserIdAndStoreIdAndStatisticsType(
+            adminService.deleteStatisticsBookmarkType(
                     event.getUserId(),
                     event.getStoreId(),
                     StatisticsType.BOOKMARK

--- a/src/main/java/com/ureca/uhyu/domain/mymap/event/MyMapEventListener.java
+++ b/src/main/java/com/ureca/uhyu/domain/mymap/event/MyMapEventListener.java
@@ -2,18 +2,21 @@ package com.ureca.uhyu.domain.mymap.event;
 
 import com.ureca.uhyu.domain.admin.entity.Statistics;
 import com.ureca.uhyu.domain.admin.enums.StatisticsType;
-import com.ureca.uhyu.domain.admin.repository.StatisticsRepository;
+import com.ureca.uhyu.domain.admin.service.AdminService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.event.EventListener;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class MyMapEventListener {
 
-    private final StatisticsRepository statisticsRepository;
+    private final AdminService adminService;
 
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMyMapToggled(MyMapToggledEvent event) {
         if (event.getAction() == MyMapToggledEvent.Action.ADD) {
             Statistics statistics = Statistics.builder()
@@ -26,10 +29,10 @@ public class MyMapEventListener {
                     .categoryName(event.getCategoryName())
                     .statisticsType(StatisticsType.MYMAP)
                     .build();
-            statisticsRepository.save(statistics);
+            adminService.saveStatistics(statistics);
         }
         else if (event.getAction() == MyMapToggledEvent.Action.REMOVE) {
-            statisticsRepository.deleteByUserIdAndStoreIdAndMyMapListIdAndStatisticsType(
+            adminService.deleteStatisticsMyMapType(
                     event.getUserId(),
                     event.getStoreId(),
                     event.getMyMapListId(),

--- a/src/main/java/com/ureca/uhyu/domain/user/event/FilterUsedEventListener.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/event/FilterUsedEventListener.java
@@ -2,18 +2,21 @@ package com.ureca.uhyu.domain.user.event;
 
 import com.ureca.uhyu.domain.admin.entity.Statistics;
 import com.ureca.uhyu.domain.admin.enums.StatisticsType;
-import com.ureca.uhyu.domain.admin.repository.StatisticsRepository;
+import com.ureca.uhyu.domain.admin.service.AdminService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.event.EventListener;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class FilterUsedEventListener {
 
-    private final StatisticsRepository statisticsRepository;
+    private final AdminService adminService;
 
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleFilterUsedEvent(FilterUsedEvent event) {
         Statistics statistics = Statistics.builder()
                 .userId(event.getUserId())
@@ -22,6 +25,6 @@ public class FilterUsedEventListener {
                 .statisticsType(StatisticsType.FILTER)
                 .build();
 
-        statisticsRepository.save(statistics);
+        adminService.saveStatistics(statistics);
     }
 }

--- a/src/main/java/com/ureca/uhyu/domain/user/event/MembershipUsedEventListener.java
+++ b/src/main/java/com/ureca/uhyu/domain/user/event/MembershipUsedEventListener.java
@@ -2,18 +2,21 @@ package com.ureca.uhyu.domain.user.event;
 
 import com.ureca.uhyu.domain.admin.entity.Statistics;
 import com.ureca.uhyu.domain.admin.enums.StatisticsType;
-import com.ureca.uhyu.domain.admin.repository.StatisticsRepository;
+import com.ureca.uhyu.domain.admin.service.AdminService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.event.EventListener;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class MembershipUsedEventListener {
 
-    private final StatisticsRepository statisticsRepository;
+    private final AdminService adminService;
 
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMembershipUsedEvent(MembershipUsedEvent event) {
         Statistics statistics = Statistics.builder()
                 .userId(event.getUserId())
@@ -25,6 +28,6 @@ public class MembershipUsedEventListener {
                 .statisticsType(StatisticsType.MEMBERSHIP_USAGE)
                 .build();
 
-        statisticsRepository.save(statistics);
+        adminService.saveStatistics(statistics);
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -53,6 +53,7 @@ logging:
     com.ureca.uhyu.domain.auth.jwt: debug
     com.ureca.uhyu.domain.auth.filter: debug
     com.ureca.uhyu.domain.auth.handler: debug
+    com.ureca.uhyu.domain.admin.service: debug
     org.hibernate.SQL: off
     org.hibernate.type.descriptor.sql.BasicBinder: debug
 

--- a/src/test/java/com/ureca/uhyu/domain/admin/service/AdminServiceTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/admin/service/AdminServiceTest.java
@@ -1,12 +1,10 @@
 package com.ureca.uhyu.domain.admin.service;
 
+import com.querydsl.core.Tuple;
 import com.ureca.uhyu.domain.admin.dto.response.StatisticsFilterRes;
-import com.ureca.uhyu.domain.user.enums.ActionType;
-import com.ureca.uhyu.domain.user.repository.actionLogs.ActionLogsRepository;
-import com.ureca.uhyu.domain.user.repository.bookmark.BookmarkRepository;
+import com.ureca.uhyu.domain.admin.enums.StatisticsType;
+import com.ureca.uhyu.domain.admin.repository.StatisticsRepository;
 import com.ureca.uhyu.domain.admin.dto.response.*;
-import com.ureca.uhyu.domain.recommendation.repository.RecommendationRepository;
-import com.ureca.uhyu.domain.user.repository.history.HistoryRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,152 +21,132 @@ import static org.mockito.Mockito.*;
 class AdminServiceTest {
 
     @Mock
-    private BookmarkRepository bookmarkRepository;
-
-    @Mock
-    private ActionLogsRepository actionLogsRepository;
-
-    @Mock
-    private RecommendationRepository recommendationRepository;
-
-    @Mock
-    private HistoryRepository historyRepository;
+    private StatisticsRepository statisticsRepository;
 
     @InjectMocks
     private AdminService adminService;
 
-    @DisplayName("카테고리, 브랜드 별 즐겨찾기 갯수 통계 조회 - 성공")
+    @DisplayName("카테고리, 브랜드 별 즐겨찾기/마이맵 갯수 통계 조회 - 성공")
     @Test
-    void findStatisticsBookmarkByCategoryAndBrand() {
+    void findStatisticsBookmarkByCategoryAndBrand_success() {
         // given
-        List<StatisticsBookmarkMyMapRes> mockResList = List.of(
-                StatisticsBookmarkMyMapRes.of(
-                        1L,
-                        "카테고리A",
-                        30,
-                        new ArrayList<>(List.of(
-                                BookmarksByBrand.of("브랜드1", 10),
-                                BookmarksByBrand.of("브랜드2", 20)
-                        ))
-                ),
-                StatisticsBookmarkMyMapRes.of(
-                        2L,
-                        "카테고리B",
-                        15,
-                        new ArrayList<>(List.of(
-                                BookmarksByBrand.of("브랜드3", 15)
-                        ))
-                )
-        );
+        Tuple tuple1 = mock(Tuple.class);
+        when(tuple1.get(0, String.class)).thenReturn("브랜드1");
+        when(tuple1.get(1, Long.class)).thenReturn(1L);
+        when(tuple1.get(2, String.class)).thenReturn("카테고리A");
+        when(tuple1.get(4, Long.class)).thenReturn(10L);
 
-        when(bookmarkRepository.findStatisticsBookmarkByCategoryAndBrand()).thenReturn(mockResList);
+        Tuple tuple2 = mock(Tuple.class);
+        when(tuple2.get(0, String.class)).thenReturn("브랜드2");
+        when(tuple2.get(1, Long.class)).thenReturn(1L);
+        when(tuple2.get(2, String.class)).thenReturn("카테고리A");
+        when(tuple2.get(4, Long.class)).thenReturn(20L);
+
+        Tuple tuple3 = mock(Tuple.class);
+        when(tuple3.get(0, String.class)).thenReturn("브랜드3");
+        when(tuple3.get(1, Long.class)).thenReturn(2L);
+        when(tuple3.get(2, String.class)).thenReturn("카테고리B");
+        when(tuple3.get(4, Long.class)).thenReturn(15L);
+
+        List<Tuple> mockTuples = List.of(tuple1, tuple2, tuple3);
+        when(statisticsRepository.findBookmarkMyMapStatistics()).thenReturn(mockTuples);
 
         // when
         List<StatisticsBookmarkMyMapRes> result = adminService.findStatisticsBookmarkByCategoryAndBrand();
 
         // then
         assertEquals(2, result.size());
-        assertEquals("카테고리A", result.get(0).categoryName());
-        assertEquals(30, result.get(0).sumStatisticsBookmarksByCategory());
-        assertEquals(2, result.get(0).bookmarksByBrandList().size());
-        assertEquals("브랜드1", result.get(0).bookmarksByBrandList().get(0).brandName());
 
-        assertEquals("카테고리B", result.get(1).categoryName());
-        assertEquals(15, result.get(1).sumStatisticsBookmarksByCategory());
-        assertEquals(1, result.get(1).bookmarksByBrandList().size());
-        assertEquals("브랜드3", result.get(1).bookmarksByBrandList().get(0).brandName());
-        verify(bookmarkRepository).findStatisticsBookmarkByCategoryAndBrand();
+        StatisticsBookmarkMyMapRes catA = result.get(0);
+        assertEquals("카테고리A", catA.categoryName());
+        assertEquals(30, catA.sumStatisticsBookmarksByCategory());
+        assertEquals(2, catA.bookmarksByBrandList().size());
+
+        StatisticsBookmarkMyMapRes catB = result.get(1);
+        assertEquals("카테고리B", catB.categoryName());
+        assertEquals(15, catB.sumStatisticsBookmarksByCategory());
+        assertEquals(1, catB.bookmarksByBrandList().size());
+
+        verify(statisticsRepository).findBookmarkMyMapStatistics();
     }
-    
-    @DisplayName("카테고리, 브랜드 별 즐겨찾기 갯수 통계 조회 - 빈 리스트")
+
+    @DisplayName("카테고리, 브랜드 별 즐겨찾기/마이맵 통계 조회 - 빈 리스트")
     @Test
-    void findStatisticsBookmarkByCategoryAndBrand_EmptyDataset() {
+    void findStatisticsBookmarkByCategoryAndBrand_empty() {
         // given
-        when(bookmarkRepository.findStatisticsBookmarkByCategoryAndBrand()).thenReturn(List.of());
+        when(statisticsRepository.findBookmarkMyMapStatistics()).thenReturn(Collections.emptyList());
 
         // when
         List<StatisticsBookmarkMyMapRes> result = adminService.findStatisticsBookmarkByCategoryAndBrand();
 
         // then
         assertTrue(result.isEmpty());
-        verify(bookmarkRepository).findStatisticsBookmarkByCategoryAndBrand();
+        verify(statisticsRepository).findBookmarkMyMapStatistics();
     }
 
-    @DisplayName("카테고리별 필터링 횟수 통계 조회 - 성공")
+    @DisplayName("카테고리별 필터링 통계 조회 - 성공")
     @Test
-    void findStatisticsFilterByCategory() {
+    void findStatisticsFilterByCategory_success() {
         // given
-        StatisticsFilterRes res1 = new StatisticsFilterRes(1L, "카페", 15);
-        StatisticsFilterRes res2 = new StatisticsFilterRes(2L, "패션", 8);
-        List<StatisticsFilterRes> mockResult = List.of(res1, res2);
+        Tuple tuple1 = mock(Tuple.class);
+        when(tuple1.get(0, Long.class)).thenReturn(1L);
+        when(tuple1.get(1, String.class)).thenReturn("카페");
+        when(tuple1.get(2, Long.class)).thenReturn(15L);
 
-        when(actionLogsRepository.findStatisticsFilterByActionType(ActionType.FILTER_USED))
-                .thenReturn(mockResult);
+        Tuple tuple2 = mock(Tuple.class);
+        when(tuple2.get(0, Long.class)).thenReturn(2L);
+        when(tuple2.get(1, String.class)).thenReturn("패션");
+        when(tuple2.get(2, Long.class)).thenReturn(8L);
+
+        when(statisticsRepository.findFilterStatistics()).thenReturn(List.of(tuple1, tuple2));
 
         // when
         List<StatisticsFilterRes> result = adminService.findStatisticsFilterByCategory();
 
         // then
         assertEquals(2, result.size());
+        assertEquals("카페", result.get(0).categoryName());
+        assertEquals(15, result.get(0).sumStatisticsFilterByCategory());
 
-        StatisticsFilterRes first = result.get(0);
-        assertEquals(1L, first.categoryId());
-        assertEquals("카페", first.categoryName());
-        assertEquals(15, first.sumStatisticsFilterByCategory());
-
-        StatisticsFilterRes second = result.get(1);
-        assertEquals(2L, second.categoryId());
-        assertEquals("패션", second.categoryName());
-        assertEquals(8, second.sumStatisticsFilterByCategory());
-
-        verify(actionLogsRepository).findStatisticsFilterByActionType(ActionType.FILTER_USED);
+        verify(statisticsRepository).findFilterStatistics();
     }
 
     @DisplayName("카테고리, 브랜드별 추천 통계 조회 - 성공")
     @Test
     void findStatisticsRecommendationByCategoryAndBrand_success() {
         // given
-        RecommendationsByBrand brand1 = RecommendationsByBrand.of("스타벅스", 12);
-        RecommendationsByBrand brand2 = RecommendationsByBrand.of("이디야", 8);
-        StatisticsRecommendationRes category1 = StatisticsRecommendationRes.of(1L, "카페", 20, List.of(brand1, brand2));
+        Tuple tuple1 = mock(Tuple.class);
+        when(tuple1.get(0, String.class)).thenReturn("브랜드1");
+        when(tuple1.get(1, Long.class)).thenReturn(1L);
+        when(tuple1.get(2, String.class)).thenReturn("카테고리A");
+        when(tuple1.get(3, Long.class)).thenReturn(10L);
 
-        RecommendationsByBrand brand3 = RecommendationsByBrand.of("무신사", 6);
-        StatisticsRecommendationRes category2 = StatisticsRecommendationRes.of(2L, "패션", 6, List.of(brand3));
+        Tuple tuple2 = mock(Tuple.class);
+        when(tuple2.get(0, String.class)).thenReturn("브랜드2");
+        when(tuple2.get(1, Long.class)).thenReturn(1L);
+        when(tuple2.get(2, String.class)).thenReturn("카테고리A");
+        when(tuple2.get(3, Long.class)).thenReturn(5L);
 
-        List<StatisticsRecommendationRes> mockResult = List.of(category1, category2);
-
-        when(recommendationRepository.findStatisticsRecommendationByCategory()).thenReturn(mockResult);
+        when(statisticsRepository.findRecommendationStatistics()).thenReturn(List.of(tuple1, tuple2));
 
         // when
         List<StatisticsRecommendationRes> result = adminService.findStatisticsRecommendationByCategoryAndBrand();
 
         // then
-        assertEquals(2, result.size());
+        assertEquals(1, result.size());
+        StatisticsRecommendationRes res = result.get(0);
+        assertEquals("카테고리A", res.categoryName());
+        assertEquals(15, res.sumStatisticsRecommendationByCategory());
+        assertEquals(2, res.recommendationsByBrandList().size());
 
-        StatisticsRecommendationRes res1 = result.get(0);
-        assertEquals(1L, res1.categoryId());
-        assertEquals("카페", res1.categoryName());
-        assertEquals(20, res1.sumStatisticsRecommendationByCategory());
-        assertEquals(2, res1.recommendationsByBrandList().size());
-        assertEquals("스타벅스", res1.recommendationsByBrandList().get(0).brandName());
-        assertEquals(12, res1.recommendationsByBrandList().get(0).sumRecommendationsByBrand());
-
-        StatisticsRecommendationRes res2 = result.get(1);
-        assertEquals(2L, res2.categoryId());
-        assertEquals("패션", res2.categoryName());
-        assertEquals(6, res2.sumStatisticsRecommendationByCategory());
-        assertEquals(1, res2.recommendationsByBrandList().size());
-        assertEquals("무신사", res2.recommendationsByBrandList().get(0).brandName());
-        assertEquals(6, res2.recommendationsByBrandList().get(0).sumRecommendationsByBrand());
-
-        verify(recommendationRepository).findStatisticsRecommendationByCategory();
+        verify(statisticsRepository).findRecommendationStatistics();
     }
 
     @DisplayName("카테고리, 브랜드별 추천 통계 조회 - 빈 리스트")
     @Test
-    void findStatisticsRecommendationByCategoryAndBrand_emptyDataset() {
+    void findStatisticsRecommendationByCategoryAndBrand_empty() {
         // given
-        when(recommendationRepository.findStatisticsRecommendationByCategory()).thenReturn(Collections.emptyList());
+        when(statisticsRepository.findRecommendationStatistics()).thenReturn(Collections.emptyList());
 
         // when
         List<StatisticsRecommendationRes> result = adminService.findStatisticsRecommendationByCategoryAndBrand();
@@ -177,45 +155,37 @@ class AdminServiceTest {
         assertNotNull(result);
         assertTrue(result.isEmpty(), "빈 리스트가 반환되어야 합니다.");
 
-        verify(recommendationRepository).findStatisticsRecommendationByCategory();
+        verify(statisticsRepository).findRecommendationStatistics();
     }
 
-    @DisplayName("카테고리, 브랜드별 멤버십 사용횟수 통계 조회 - 성공")
+    @DisplayName("카테고리, 브랜드별 멤버십 사용 통계 조회 - 성공")
     @Test
     void findStatisticsMembershipUsageByCategoryAndBrand_success() {
         // given
-        List<MembershipUsageByBrand> usageList1 = List.of(
-                MembershipUsageByBrand.of("브랜드A", 5),
-                MembershipUsageByBrand.of("브랜드B", 3)
-        );
+        Tuple tuple = mock(Tuple.class);
+        when(tuple.get(0, String.class)).thenReturn("브랜드1");
+        when(tuple.get(1, Long.class)).thenReturn(1L);
+        when(tuple.get(2, String.class)).thenReturn("카테고리1");
+        when(tuple.get(3, Long.class)).thenReturn(7L);
 
-        List<MembershipUsageByBrand> usageList2 = List.of(
-                MembershipUsageByBrand.of("브랜드C", 2)
-        );
-
-        List<StatisticsMembershipUsageRes> expected = List.of(
-                StatisticsMembershipUsageRes.of(1L, "카테고리1", 8, usageList1),
-                StatisticsMembershipUsageRes.of(2L, "카테고리2", 2, usageList2)
-        );
-
-        when(historyRepository.findStatisticsMembershipUsageByCategory()).thenReturn(expected);
+        when(statisticsRepository.findMembershipUsageStatistics()).thenReturn(List.of(tuple));
 
         // when
         List<StatisticsMembershipUsageRes> result = adminService.findStatisticsMembershipUsageByCategoryAndBrand();
 
         // then
-        assertEquals(2, result.size());
+        assertEquals(1, result.size());
         assertEquals("카테고리1", result.get(0).categoryName());
-        assertEquals(8, result.get(0).sumStatisticsMembershipUsageByCategory());
-        assertEquals("브랜드A", result.get(0).membershipUsageByBrandList().get(0).brandName());
-        verify(historyRepository).findStatisticsMembershipUsageByCategory();
+        assertEquals(7, result.get(0).sumStatisticsMembershipUsageByCategory());
+
+        verify(statisticsRepository).findMembershipUsageStatistics();
     }
 
-    @DisplayName("카테고리, 브랜드별 멤버십 사용횟수 통계 조회 - 빈 리스트")
+    @DisplayName("카테고리, 브랜드별 멤버십 사용 통계 조회 - 빈 리스트")
     @Test
-    void findStatisticsMembershipUsageByCategoryAndBrand_emptyDataset() {
+    void findStatisticsMembershipUsageByCategoryAndBrand_empty() {
         // given
-        when(historyRepository.findStatisticsMembershipUsageByCategory()).thenReturn(List.of());
+        when(statisticsRepository.findMembershipUsageStatistics()).thenReturn(Collections.emptyList());
 
         // when
         List<StatisticsMembershipUsageRes> result = adminService.findStatisticsMembershipUsageByCategoryAndBrand();
@@ -223,52 +193,51 @@ class AdminServiceTest {
         // then
         assertNotNull(result);
         assertTrue(result.isEmpty());
-        verify(historyRepository).findStatisticsMembershipUsageByCategory();
+        verify(statisticsRepository).findMembershipUsageStatistics();
     }
 
     @DisplayName("전체 통계 조회 - 성공")
     @Test
     void findStatisticsTotal_success() {
         // given
-        Long bookmarkCount = 100L;
-        Long filterCount = 25L;
-        Long historyCount = 55L;
-
-        when(bookmarkRepository.count()).thenReturn(bookmarkCount);
-        when(actionLogsRepository.countByActionType(ActionType.FILTER_USED)).thenReturn(filterCount);
-        when(historyRepository.count()).thenReturn(historyCount);
+        when(statisticsRepository.countByStatisticsTypeIn(List.of(StatisticsType.BOOKMARK, StatisticsType.MYMAP)))
+                .thenReturn(100L);
+        when(statisticsRepository.countByStatisticsType(StatisticsType.FILTER))
+                .thenReturn(25L);
+        when(statisticsRepository.countByStatisticsType(StatisticsType.MEMBERSHIP_USAGE))
+                .thenReturn(55L);
 
         // when
         StatisticsTotalRes result = adminService.findStatisticsTotal();
 
         // then
-        assertEquals(bookmarkCount, result.totalBookmark());
-        assertEquals(filterCount, result.totalFiltering());
-        assertEquals(historyCount, result.totalMembershipUsage());
+        assertEquals(100L, result.totalBookmarkMyMap());
+        assertEquals(25L, result.totalFiltering());
+        assertEquals(55L, result.totalMembershipUsage());
 
-        verify(bookmarkRepository).count();
-        verify(actionLogsRepository).countByActionType(ActionType.FILTER_USED);
-        verify(historyRepository).count();
+        verify(statisticsRepository).countByStatisticsTypeIn(List.of(StatisticsType.BOOKMARK, StatisticsType.MYMAP));
+        verify(statisticsRepository).countByStatisticsType(StatisticsType.FILTER);
+        verify(statisticsRepository).countByStatisticsType(StatisticsType.MEMBERSHIP_USAGE);
     }
 
     @DisplayName("전체 통계 조회 - db에 값이 든게 없을경우")
     @Test
     void findStatisticsTotal_emptyDataset() {
         // given
-        when(bookmarkRepository.count()).thenReturn(0L);
-        when(actionLogsRepository.countByActionType(ActionType.FILTER_USED)).thenReturn(0L);
-        when(historyRepository.count()).thenReturn(0L);
+        when(statisticsRepository.countByStatisticsTypeIn(List.of(StatisticsType.BOOKMARK, StatisticsType.MYMAP))).thenReturn(0L);
+        when(statisticsRepository.countByStatisticsType(StatisticsType.FILTER)).thenReturn(0L);
+        when(statisticsRepository.countByStatisticsType(StatisticsType.MEMBERSHIP_USAGE)).thenReturn(0L);
 
         // when
         StatisticsTotalRes result = adminService.findStatisticsTotal();
 
         // then
-        assertEquals(0L, result.totalBookmark());
+        assertEquals(0L, result.totalBookmarkMyMap());
         assertEquals(0L, result.totalFiltering());
         assertEquals(0L, result.totalMembershipUsage());
 
-        verify(bookmarkRepository).count();
-        verify(actionLogsRepository).countByActionType(ActionType.FILTER_USED);
-        verify(historyRepository).count();
+        verify(statisticsRepository).countByStatisticsTypeIn(List.of(StatisticsType.BOOKMARK, StatisticsType.MYMAP));
+        verify(statisticsRepository).countByStatisticsType(StatisticsType.FILTER);
+        verify(statisticsRepository).countByStatisticsType(StatisticsType.MEMBERSHIP_USAGE);
     }
 }

--- a/src/test/java/com/ureca/uhyu/domain/map/service/MapServiceImplTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/map/service/MapServiceImplTest.java
@@ -7,6 +7,8 @@ import com.ureca.uhyu.domain.brand.enums.BenefitType;
 import com.ureca.uhyu.domain.brand.enums.StoreType;
 import com.ureca.uhyu.domain.map.dto.response.MapBookmarkRes;
 import com.ureca.uhyu.domain.map.dto.response.MapRes;
+import com.ureca.uhyu.domain.map.event.BookmarkEventListener;
+import com.ureca.uhyu.domain.map.event.BookmarkToggledEvent;
 import com.ureca.uhyu.domain.recommendation.entity.Recommendation;
 import com.ureca.uhyu.domain.recommendation.repository.RecommendationRepository;
 import com.ureca.uhyu.domain.store.dto.response.StoreDetailRes;
@@ -34,6 +36,7 @@ import org.locationtech.jts.geom.Point;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.lang.reflect.Field;
 import java.util.List;
@@ -64,6 +67,9 @@ class MapServiceImplTest {
 
     @Mock
     private BookmarkListRepository bookmarkListRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     private final GeometryFactory geometryFactory = new GeometryFactory();
     private final Point dummyPoint = geometryFactory.createPoint(new Coordinate(127.0, 37.5));
@@ -409,6 +415,8 @@ class MapServiceImplTest {
 
             assertThat(res.storeId()).isEqualTo(1L);
             assertThat(res.isBookmarked()).isTrue(); // 추가된 상태
+
+            verify(eventPublisher).publishEvent(any(BookmarkToggledEvent.class));
         }
 
         @Test
@@ -425,6 +433,8 @@ class MapServiceImplTest {
 
             assertThat(res.storeId()).isEqualTo(1L);
             assertThat(res.isBookmarked()).isFalse(); // 삭제된 상태
+
+            verify(eventPublisher).publishEvent(any(BookmarkToggledEvent.class));
         }
     }
 }

--- a/src/test/java/com/ureca/uhyu/domain/mymap/service/MyMapServiceTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/mymap/service/MyMapServiceTest.java
@@ -11,6 +11,7 @@ import com.ureca.uhyu.domain.mymap.dto.response.*;
 import com.ureca.uhyu.domain.mymap.entity.MyMap;
 import com.ureca.uhyu.domain.mymap.entity.MyMapList;
 import com.ureca.uhyu.domain.mymap.enums.MarkerColor;
+import com.ureca.uhyu.domain.mymap.event.MyMapToggledEvent;
 import com.ureca.uhyu.domain.mymap.repository.MyMapListRepository;
 import com.ureca.uhyu.domain.mymap.repository.MyMapRepository;
 import com.ureca.uhyu.domain.recommendation.repository.RecommendationRepository;
@@ -37,6 +38,7 @@ import org.locationtech.jts.geom.Point;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.lang.reflect.Field;
 import java.util.List;
@@ -67,7 +69,7 @@ class MyMapServiceTest {
     private StoreRepository storeRepository;
 
     @Mock
-    private RecommendationRepository recommendationRepository;
+    private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private MyMapService myMapService;
@@ -512,6 +514,8 @@ class MyMapServiceTest {
 
         verify(myMapRepository).save(any(MyMap.class));
         verify(myMapRepository, never()).delete(any(MyMap.class));
+
+        verify(eventPublisher).publishEvent(any(MyMapToggledEvent.class));
     }
 
     @DisplayName("MyMap 토글 - 매장 해제 성공")
@@ -543,6 +547,8 @@ class MyMapServiceTest {
         assertFalse(result.isMyMapped());
         verify(myMapRepository).delete(existing);
         verify(myMapRepository, never()).save(any(MyMap.class));
+
+        verify(eventPublisher).publishEvent(any(MyMapToggledEvent.class));
     }
 
     @DisplayName("MyMap 토글 - 다른 유저의 마이맵에 접근 시 실패")
@@ -598,10 +604,23 @@ class MyMapServiceTest {
                 .build();
         setId(category, 1L);
 
-        Benefit benefit = Benefit.builder()
+        Benefit benefit1 = Benefit.builder()
                 .description("혜택1")
+                .grade(Grade.GOOD)
                 .build();
-        setId(benefit, 2L);
+        setId(benefit1, 1L);
+
+        Benefit benefit2 = Benefit.builder()
+                .description("혜택2")
+                .grade(Grade.VIP)
+                .build();
+        setId(benefit2, 2L);
+
+        Benefit benefit3 = Benefit.builder()
+                .description("혜택3")
+                .grade(Grade.VVIP)
+                .build();
+        setId(benefit3, 3L);
 
         Brand brand = Brand.builder()
                 .category(category)
@@ -610,7 +629,7 @@ class MyMapServiceTest {
                 .usageMethod("모바일 바코드 제시")
                 .usageLimit("1일 1회")
                 .storeType(StoreType.OFFLINE)
-                .benefits(List.of(benefit))
+                .benefits(List.of(benefit1, benefit2, benefit3))
                 .build();
         return brand;
     }

--- a/src/test/java/com/ureca/uhyu/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/ureca/uhyu/domain/user/service/UserServiceTest.java
@@ -5,6 +5,7 @@ import com.ureca.uhyu.domain.brand.entity.Brand;
 import com.ureca.uhyu.domain.brand.entity.Category;
 import com.ureca.uhyu.domain.brand.enums.StoreType;
 import com.ureca.uhyu.domain.brand.repository.BrandRepository;
+import com.ureca.uhyu.domain.brand.repository.CategoryRepository;
 import com.ureca.uhyu.domain.recommendation.entity.RecommendationBaseData;
 import com.ureca.uhyu.domain.recommendation.enums.DataType;
 import com.ureca.uhyu.domain.recommendation.repository.RecommendationBaseDataRepository;
@@ -17,6 +18,7 @@ import com.ureca.uhyu.domain.user.entity.Bookmark;
 import com.ureca.uhyu.domain.user.entity.BookmarkList;
 import com.ureca.uhyu.domain.user.entity.User;
 import com.ureca.uhyu.domain.user.enums.*;
+import com.ureca.uhyu.domain.user.event.FilterUsedEvent;
 import com.ureca.uhyu.domain.user.repository.*;
 import com.ureca.uhyu.domain.user.repository.actionLogs.ActionLogsRepository;
 import com.ureca.uhyu.domain.user.repository.bookmark.BookmarkListRepository;
@@ -32,6 +34,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.lang.reflect.Field;
 import java.time.LocalDateTime;
@@ -64,6 +67,12 @@ class UserServiceTest {
 
     @Mock
     private ActionLogsRepository actionLogsRepository;
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private UserService userService;
@@ -497,6 +506,13 @@ class UserServiceTest {
         setId(user, 2L);
         ActionLogsReq req = new ActionLogsReq(ActionType.FILTER_USED, null, 5L);
 
+        Brand brand = createBrand("brand1", "brand1.img");
+
+        Category category = new Category("카페", List.of(brand));
+        setId(category, 5L);
+
+        when(categoryRepository.findById(5L)).thenReturn(Optional.of(category));
+
         // when
         SaveUserInfoRes res = userService.saveActionLogs(user, req);
 
@@ -511,6 +527,8 @@ class UserServiceTest {
         assertEquals(ActionType.FILTER_USED, saved.getActionType());
 
         assertEquals(2L, res.userId());
+
+        verify(eventPublisher).publishEvent(any(FilterUsedEvent.class));
     }
 
     @Test


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 이벤트를 통해 실 데이터가 저장 후 통계 데이터가 저장되게 처리하여 관심사를 분리하고자 하였는데, 트랜잭션 커밋 후 이벤트가 실행되도록 하여 롤백 시 이벤트가 실행되지 않도록 보장하고자 @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)로 이벤트 리스너 적용.
- 리스너와 서비스 계층간의 역할을 명확히 분리하기 위해 save, delete의 역할을 이벤트 리스너->adminService로 변경
-  

## ✨ 기타 참고 사항
<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **기능 개선**
  * 통계 관련 이벤트 처리 시 서비스 레이어를 통해 데이터 저장 및 삭제가 이루어지도록 변경되었습니다.
  * 이벤트 리스너가 트랜잭션 커밋 이후에 동작하도록 개선되어 데이터 일관성이 향상되었습니다.
  * 북마크 및 마이맵 토글 시 관련 이벤트가 정상적으로 발행되는지 검증하는 테스트가 추가되었습니다.
  * 브랜드 생성 시 다양한 등급의 혜택이 포함되도록 테스트 데이터가 확장되었습니다.
  * 사용자 서비스 저장 로직에 카테고리 조회 및 필터 사용 이벤트 발행 검증이 추가되었습니다.

* **운영 환경**
  * 관리자 서비스 도메인에 대한 디버그 로그 레벨이 추가되어, 개발 환경에서 더 상세한 로그를 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->