### PR TITLE
[FIX][UHYU-394] : www가 없는 도메인 CORS 에러 해결

### DIFF
--- a/src/main/java/com/ureca/uhyu/global/config/SecurityConfig.java
+++ b/src/main/java/com/ureca/uhyu/global/config/SecurityConfig.java
@@ -116,7 +116,8 @@ public class SecurityConfig {
                 "http://localhost:3000",
                 "http://localhost:5173",
                 "https://www.u-hyu.site",
-                "https://api.u-hyu.site"
+                "https://api.u-hyu.site",
+                "https://u-hyu.site"
         ));
 
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));


### PR DESCRIPTION
## 📌 작업 개요

- 프론트 설정 변화에 따른 SecurityConfig 수정
- CORS 설정에 "https://u-hyu.site" 추가했습니다.

## ✨ 기타 참고 사항

- 

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * CORS 허용 origin에 "https://u-hyu.site"가 추가되어 해당 도메인에서의 접근이 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->