### PR TITLE
[FIX][UHYU-394] : 로그인 redirect 에러 해결을 위한 수정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,7 @@ app:
   frontend:
     url:
       local: http://localhost:5173
-      prod: https://www.u-hyu.site
+      prod: https://u-hyu.site
 
 management:
   endpoints:


### PR DESCRIPTION
## 📌 작업 개요

- redirect가 www가 붙은 상태로 되서 페이지 이동이 안되는 문제 해결 

## ✨ 기타 참고 사항

- 

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 프로덕션 환경의 프론트엔드 URL이 `https://www.u-hyu.site`에서 `https://u-hyu.site`로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->