### PR TITLE
[REFACTOR][UHYU-418] 지도 조회 성능 최적화 최종

### DIFF
--- a/src/main/java/com/ureca/uhyu/domain/map/dto/response/MapRes.java
+++ b/src/main/java/com/ureca/uhyu/domain/map/dto/response/MapRes.java
@@ -81,4 +81,19 @@ public record MapRes(
                         null                                            //좌표값 없으므로 null
                 );
         }
+
+        public MapRes(Long storeId, String storeName, String categoryName, String addressDetail,
+                      String benefit, String logoImage, String brandName, Long brandId,
+                      Double latitude, Double longitude) {
+                this.storeId = storeId;
+                this.storeName = storeName;
+                this.categoryName = categoryName;
+                this.addressDetail = addressDetail;
+                this.benefit = benefit;
+                this.logoImage = logoImage;
+                this.brandName = brandName;
+                this.brandId = brandId;
+                this.latitude = latitude;
+                this.longitude = longitude;
+        }
 }

--- a/src/main/java/com/ureca/uhyu/domain/map/service/MapServiceImpl.java
+++ b/src/main/java/com/ureca/uhyu/domain/map/service/MapServiceImpl.java
@@ -45,10 +45,7 @@ public class MapServiceImpl implements MapService {
 
     @Override
     public List<MapRes> getFilteredStores(Double lat, Double lon, Double radius, String categoryName, String brandName) {
-        List<Store> stores = storeRepositoryCustom.findStoresByFilters(lat, lon, radius, categoryName, brandName);
-        return stores.stream()
-                .map(MapRes::from)
-                .toList();
+        return storeRepositoryCustom.findStoresByFilters(lat, lon, radius, categoryName, brandName);
     }
 
     @Override

--- a/src/main/java/com/ureca/uhyu/domain/store/repository/StoreRepositoryCustom.java
+++ b/src/main/java/com/ureca/uhyu/domain/store/repository/StoreRepositoryCustom.java
@@ -1,10 +1,11 @@
 package com.ureca.uhyu.domain.store.repository;
 
+import com.ureca.uhyu.domain.map.dto.response.MapRes;
 import com.ureca.uhyu.domain.store.entity.Store;
 import java.util.List;
 
 public interface StoreRepositoryCustom {
-    List<Store> findStoresByFilters(Double lon, Double lat, Double radius, String categoryName, String brandName);
+    List<MapRes> findStoresByFilters(Double lon, Double lat, Double radius, String categoryName, String brandName);
 
     List<Store> findNearestStores(Double lat, Double lon, List<Long> brandIds);
 }

--- a/src/main/java/com/ureca/uhyu/domain/store/repository/StoreRepositoryCustomImpl.java
+++ b/src/main/java/com/ureca/uhyu/domain/store/repository/StoreRepositoryCustomImpl.java
@@ -1,21 +1,28 @@
 package com.ureca.uhyu.domain.store.repository;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberTemplate;
-import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.ureca.uhyu.domain.brand.entity.QBenefit;
 import com.ureca.uhyu.domain.brand.entity.QBrand;
 import com.ureca.uhyu.domain.brand.entity.QCategory;
+import com.ureca.uhyu.domain.map.dto.response.MapRes;
 import com.ureca.uhyu.domain.store.entity.QStore;
 import com.ureca.uhyu.domain.store.entity.Store;
+import com.ureca.uhyu.domain.user.enums.Grade;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+
+import static com.querydsl.core.types.Projections.constructor;
 
 @Repository
 @RequiredArgsConstructor
@@ -28,29 +35,19 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
     private final QCategory category = QCategory.category;
     private final QBenefit benefit = QBenefit.benefit;
 
-    private Predicate withinRadius(double lat, double lon, double radius) {
+    private Predicate withinRadius(double lat, double lon, double radiusInMeters) {
+        // 미터(m) 단위의 radiusMeters를 degree(각도) 단위로 변환
+        double radiusInDegrees = radiusInMeters / (111_320.0 * Math.cos(Math.toRadians(lat)));
+
         return Expressions.booleanTemplate(
-                "cast(ST_DWithin(" +
-                        "ST_Transform({0}, 3857), " +
-                        "ST_Transform(ST_SetSRID(ST_MakePoint({1}, {2}), 4326), 3857), " +
-                        "{3}) as boolean)",
-                store.geom, lon, lat, radius
+                "CAST(ST_DWithin({0}, ST_SetSRID(ST_MakePoint({1}, {2}), 4326), {3}) AS boolean)",
+                store.geom, lon, lat, radiusInDegrees
         );
     }
 
-    private JPAQuery<Store> baseStoreQuery() {
-        return queryFactory
-                .selectFrom(store)
-                .leftJoin(store.brand, brand).fetchJoin()
-                .leftJoin(brand.category, category).fetchJoin()
-                .leftJoin(brand.benefits, benefit).fetchJoin()
-                .distinct();
-    }
-
     @Override
-    public List<Store> findStoresByFilters(Double lat, Double lon, Double radius, String categoryName, String brandName) {
+    public List<MapRes> findStoresByFilters(Double lat, Double lon, Double radius, String categoryName, String brandName) {
         BooleanBuilder builder = new BooleanBuilder();
-
         builder.and(withinRadius(lat, lon, radius));
 
         if (categoryName != null && !categoryName.isBlank()) {
@@ -61,7 +58,35 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
             builder.and(brand.brandName.containsIgnoreCase(brandName));
         }
 
-        return baseStoreQuery()
+        // ✅ grade.GOOD에 해당하는 혜택 하나만 가져오기 위한 서브쿼리
+        QBenefit subBenefit = new QBenefit("subBenefit");
+
+        var benefitSubQuery = JPAExpressions
+                .select(subBenefit.description)
+                .from(subBenefit)
+                .where(
+                        subBenefit.brand.id.eq(brand.id),
+                        subBenefit.grade.eq(Grade.GOOD)
+                )
+                .limit(1);
+
+        // ✅ DTO로 바로 Projection
+        return queryFactory
+                .select(constructor(MapRes.class,
+                        store.id,
+                        store.name,
+                        category.categoryName,
+                        store.addrDetail,
+                        benefitSubQuery, // 🟢 benefit을 조인하지 않고 서브쿼리로
+                        brand.logoImage,
+                        brand.brandName,
+                        brand.id,
+                        Expressions.numberTemplate(Double.class, "ST_Y({0})", store.geom),
+                        Expressions.numberTemplate(Double.class, "ST_X({0})", store.geom)
+                ))
+                .from(store)
+                .leftJoin(store.brand, brand)
+                .leftJoin(brand.category, category)
                 .where(builder)
                 .fetch();
     }
@@ -72,29 +97,36 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
             return List.of();
         }
 
+        // ST_Distance 사용으로 성능 개선 (구면 거리 계산 제거)
         NumberTemplate<Double> distanceExpr = Expressions.numberTemplate(Double.class,
-                "ST_DistanceSphere({0}, ST_SetSRID(ST_MakePoint({1}, {2}), 4326))",
+                "ST_Distance({0}, ST_SetSRID(ST_MakePoint({1}, {2}), 4326))",
                 store.geom, lon, lat
         );
 
-        List<Store> result = new ArrayList<>();
+        // 단일 쿼리로 모든 브랜드의 매장 조회
+        List<Tuple> results = queryFactory
+                .select(store, distanceExpr.as("distance"))
+                .from(store)
+                .leftJoin(store.brand, brand).fetchJoin()
+                .leftJoin(brand.category, category).fetchJoin()
+                .leftJoin(brand.benefits, benefit).fetchJoin()
+                .where(store.brand.id.in(brandIds))
+                .orderBy(store.brand.id.asc(), distanceExpr.asc())
+                .fetch();
 
-        for (Long brandId : brandIds) {
-            Store nearest = queryFactory
-                    .selectFrom(store)
-                    .leftJoin(store.brand, brand).fetchJoin()
-                    .leftJoin(brand.category, category).fetchJoin()
-                    .leftJoin(brand.benefits, benefit).fetchJoin()
-                    .where(store.brand.id.eq(brandId))
-                    .orderBy(distanceExpr.asc())
-                    .limit(1)
-                    .fetchOne();
+        // 브랜드별로 가장 가까운 매장만 선택 (LinkedHashMap으로 순서 보장)
+        Map<Long, Store> nearestByBrand = new LinkedHashMap<>();
 
-            if (nearest != null) {
-                result.add(nearest);
+        for (Tuple tuple : results) {
+            Store storeEntity = tuple.get(store);
+            Long brandId = storeEntity.getBrand().getId();
+
+            // 각 브랜드별로 첫 번째(가장 가까운) 매장만 저장
+            if (!nearestByBrand.containsKey(brandId)) {
+                nearestByBrand.put(brandId, storeEntity);
             }
         }
 
-        return result;
+        return new ArrayList<>(nearestByBrand.values());
     }
 }


### PR DESCRIPTION
## 📌 작업 개요

- 지도 조회 api(/map/store)의 성능을 최적화 하였습니다.
- 기존의 Store 객체를 가져와서 MapRes로 반환하는 방식에서 Repository단에서 애초에 MapRes에 매핑하도록 수정
- PostGIS 함수 개선 -> 기존의 좌표계 변환으로 인한 오버헤드가 없는 방식으로 수정
- benefit 테이블 JOIN으로 인한  불필요한 연산 발생 및 속도 저하 문제 해결
- benefit-grade 복합 인덱스 도입
- store_pk 인덱스 도입

## ✨ 기타 참고 사항

- 아래의 링크에 자세한 내용이 적혀있습니다. 참고해주세요.
url : https://github.com/U-Final/U-Hyu-be/wiki 

## ✅ PR 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] application.yml 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드/주석 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **기능 개선**
  * 매장 검색 시 반환되는 결과가 기존 엔티티가 아닌 DTO 형태로 제공되어, 매장 정보 조회 시 응답 속도 및 일관성이 향상되었습니다.
  * 브랜드별로 가까운 매장을 더욱 빠르고 정확하게 조회할 수 있도록 성능이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->